### PR TITLE
Enable sequence packing with FlashAttention-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Install this library as a local editable installation. Run the following command
 
 ```pip install -e .```
 
+Then install FlashAttention-2.
+
+```pip install flash-attn --no-build-isolation```
+
 # Loading Autoencoders
 
 This library uses NNsight to load and edit a model with autoencoders. We provide wrappers to load GPT-2 autoencoders trained by [OpenAI](https://github.com/openai/sparse_autoencoder), for the [GemmaScope SAEs](https://arxiv.org/abs/2408.05147) and for some SAEs train by EleutherAI using [SAE](https://github.com/EleutherAI/sae). See the [examples](examples/loading_saes.ipynb) directory for specific examples.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 keywords = ["interpretability", "explainable-ai"]
 dependencies = [
+    "transformers>=4.48.0",
     "datasets",
     "nnsight",
     "orjson",
@@ -21,6 +22,7 @@ dependencies = [
     "blobfile",
     "transformer_lens",
     "bitsandbytes",
+    # "flash-attn", # Install using: pip install flash-attn --no-build-isolation
 ]
 
 [tool.pyright]

--- a/sae_auto_interp/utils.py
+++ b/sae_auto_interp/utils.py
@@ -1,5 +1,56 @@
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, default_data_collator
+from typing import List, Dict
 import torch
+
+def packed_data_collator(input_ids: List[Dict], return_tensors: str = "pt"):
+    """
+    Collates input IDs into a batch.
+
+    Args:
+        input_ids (List[Dict]): The input IDs to collate.
+        return_tensors (str, optional): The type of tensors to return. Defaults to "pt".
+
+    Returns:
+        Dict: The collated batch.
+    """
+    batch = {"input_ids": [], "position_ids": []}
+    for input_id in input_ids:
+        batch["input_ids"] += input_id
+        batch["position_ids"] += list(range(len(input_id)))
+    
+    return default_data_collator([batch], return_tensors=return_tensors)
+
+def load_dataset(
+    ctx_len: int,
+    tokenizer: AutoTokenizer,
+    dataset_repo: str,
+    dataset_split: str,
+    dataset_name: str = "",
+    column_name: str = "raw_content",
+    seed: int = 22,
+) -> torch.Tensor:
+    """
+    Load a Hugging Face dataset, tokenize it, shuffle it, and pack it.
+
+    Args:
+        ctx_len (int): Context length for tokenization.
+        tokenizer (AutoTokenizer): The tokenizer to use.
+        dataset_repo (str): The dataset repository name.
+        dataset_split (str): The dataset split to use.
+        dataset_name (str, optional): The dataset name. Defaults to "".
+        column_name (str, optional): The column name to use for tokenization. Defaults to "text".
+        seed (int, optional): Random seed for shuffling. Defaults to 22.
+
+    Returns:
+        torch.Tensor: The tokenized, shuffled, and packed dataset.
+    """
+    from datasets import load_dataset
+    dataset = load_dataset(dataset_repo, name=dataset_name, split=dataset_split)
+    dataset = dataset.shuffle(seed)
+    dataset = dataset.map(lambda x: tokenizer(x[column_name], add_special_tokens=False, return_attention_mask=False), batched=True)
+    dataset = dataset.map(lambda x: packed_data_collator(x['input_ids']), batched=True, batch_size=10, remove_columns=dataset.column_names) # TODO: Change hardcoded batch size
+
+    return dataset
 
 def load_tokenized_data(
     ctx_len: int,


### PR DESCRIPTION
Currently, datasets are prepared for caching using `transformer_lens`' `tokenize_and_concatenate()`. This is problematic because sequences are concatenated as is, and no special handling is done to avoid cross-sequence attention contamination. In addition, sequences are separated by EOS tokens, which is not ideal when training SAEs.

An alternative can be to have one sequence per sample in each batch, but this requires padding which wastes GPU resources and is thus sub-optimal.

This PR brings the ability to "pack" sequences together, meaning that sequences in a batch are concatenated to form a single long sample containing all sequences and avoid padding. To avoid attention contamination, FlashAttension-2 is used with the ability to pass a `position_ids` argument to bypass the need to materialize attention masks in memory (which is impractical). Using FA2 also brings a speed boost which is always welcome.
For additional details, see: https://huggingface.co/blog/packing-with-FA2

Currently, FA2 with `position_ids` is only implemented for some models in `transformers`. I'm working on a patch to bring it to more models, specifically GPT-NeoX-based models (e.g., Pythia) and GPT-2. Until it's upstreamed, this PR uses my fork of the library.

## Things done
- [x] Add the dataloader for handling packing sequences `load_dataset()`
- [ ] Eventually remove `load_tokenized_data()`
- [x] Upstream FA2 patch to `transformers`
- [ ] Dynamically pack sequences to have a consistent number of tokens per batch (challenging)
- [ ] Update caching to work with the new dataset format
- [ ] Update examples