### PR TITLE
Set temperature to 0 for single-shot generations + other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ from delphi.explainers import  explanation_loader,random_explanation_loader
 def scorer_preprocess(result):
         record = result.record 
         record.explanation = result.explanation
-        record.extra_examples = record.random_examples
+        record.extra_examples = record.negative_examples
         return record
 
 def scorer_postprocess(result, score_dir):

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ from delphi.explainers import  explanation_loader,random_explanation_loader
 def scorer_preprocess(result):
         record = result.record 
         record.explanation = result.explanation
-        record.extra_examples = record.negative_examples
+        record.extra_examples = record.not_active
         return record
 
 def scorer_postprocess(result, score_dir):

--- a/delphi/__main__.py
+++ b/delphi/__main__.py
@@ -283,7 +283,7 @@ async def process_cache(
     def scorer_preprocess(result):
         record = result.record
         record.explanation = result.explanation
-        record.extra_examples = record.negative_examples
+        record.extra_examples = record.not_active
         return record
 
     # Saves the score to a file

--- a/delphi/__main__.py
+++ b/delphi/__main__.py
@@ -283,7 +283,7 @@ async def process_cache(
     def scorer_preprocess(result):
         record = result.record
         record.explanation = result.explanation
-        record.extra_examples = record.random_examples
+        record.extra_examples = record.negative_examples
         return record
 
     # Saves the score to a file

--- a/delphi/__main__.py
+++ b/delphi/__main__.py
@@ -298,7 +298,7 @@ async def process_cache(
             DetectionScorer(
                 client,
                 tokenizer=dataset.tokenizer,  # type: ignore
-                batch_size=16,
+                batch_size=10,
                 verbose=False,
                 log_prob=False,
             ),
@@ -309,7 +309,7 @@ async def process_cache(
             FuzzingScorer(
                 client,
                 tokenizer=dataset.tokenizer,  # type: ignore
-                batch_size=16,
+                batch_size=10,
                 verbose=False,
                 log_prob=False,
             ),

--- a/delphi/clients/offline.py
+++ b/delphi/clients/offline.py
@@ -86,7 +86,6 @@ class Offline(Client):
             if self.statistics:
                 non_cached_tokens = len(self.tokenizer.apply_chat_template(batch[-1:], add_generation_prompt=True, tokenize=True))
                 statistics.append(Statistics(num_prompt_tokens=len(prompt), num_new_tokens=non_cached_tokens, num_generated_tokens=0))
-        print("temperature: ", self.sampling_params.temperature)
         response = await loop.run_in_executor(
             None, 
             partial(self.client.generate, prompt_token_ids=prompts, sampling_params=self.sampling_params, use_tqdm=False)

--- a/delphi/clients/offline.py
+++ b/delphi/clients/offline.py
@@ -170,7 +170,7 @@ class Offline(Client):
             try:
                 results = await self.process_func(batch, batch_kwargs)
                 batch_count += 1
-                # print(f"Batch {batch_count} finished processing. {len(results)} prompts processed.")
+                
                 for result, future in zip(results, batch_futures):
                     if not future.done():
                         future.set_result(result)

--- a/delphi/config.py
+++ b/delphi/config.py
@@ -35,7 +35,9 @@ class FeatureConfig(Serializable):
     """Number of features in each autoencoder"""
 
     min_examples: int = 200
-    """Minimum number of examples for a feature to be explained and scored."""
+    """Minimum number of examples to generate for a single feature. 
+    If the number of activating examples is less than this, the 
+    feature will not be explained and scored."""
 
     max_examples: int = 10_000
     """Maximum number of examples to generate for a single feature."""

--- a/delphi/config.py
+++ b/delphi/config.py
@@ -16,7 +16,8 @@ class ExperimentConfig(Serializable):
     """Number of feature activation quantiles to sample."""
 
     example_ctx_len: int = 32
-    """Length of each sampled example sequence. Longer sequences reduce detection scoring performance."""
+    """Length of each sampled example sequence. Longer sequences 
+    reduce detection scoring performance in weak models."""
 
     n_random: int = 50
     """Number of random examples to sample."""

--- a/delphi/explainers/__init__.py
+++ b/delphi/explainers/__init__.py
@@ -1,4 +1,5 @@
 from .default.default import DefaultExplainer
+from .single_token_explainer import SingleTokenExplainer
 from .explainer import Explainer, explanation_loader, random_explanation_loader
 
-__all__ = ["Explainer", "DefaultExplainer", "explanation_loader", "random_explanation_loader"]
+__all__ = ["Explainer", "DefaultExplainer", "SingleTokenExplainer", "explanation_loader", "random_explanation_loader"]

--- a/delphi/explainers/default/default.py
+++ b/delphi/explainers/default/default.py
@@ -16,6 +16,7 @@ class DefaultExplainer(Explainer):
         activations: bool = False,
         cot: bool = False,
         threshold: float = 0.6,
+        temperature: float = 0.,
         **generation_kwargs,
     ):
         self.client = client
@@ -25,14 +26,16 @@ class DefaultExplainer(Explainer):
         self.activations = activations
         self.cot = cot
         self.threshold = threshold
+        self.temperature = temperature
         self.generation_kwargs = generation_kwargs
 
-
     async def __call__(self, record):
-       
+
         messages = self._build_prompt(record.train)
-        
-        response = await self.client.generate(messages, **self.generation_kwargs)
+
+        response = await self.client.generate(
+            messages, temperature=self.temperature, **self.generation_kwargs
+        )
 
         try:
             explanation = self.parse_explanation(response.text)

--- a/delphi/explainers/default/prompt_builder.py
+++ b/delphi/explainers/default/prompt_builder.py
@@ -1,6 +1,4 @@
-from typing import List
-
-from .prompts import example, system
+from .prompts import example, system, system_single_token
 
 
 def build_examples(
@@ -44,7 +42,24 @@ def build_prompt(
 
     messages.extend(few_shot_examples)
 
-    user_start = f"\n{examples}\n"
+    user_start = f"WORDS: {examples}"
+
+    messages.append(
+        {
+            "role": "user",
+            "content": user_start,
+        }
+    )
+
+    return messages
+
+def build_single_token_prompt(
+    examples,
+):
+    
+    messages = system_single_token()
+
+    user_start = f"WORDS: {examples}"
 
     messages.append(
         {

--- a/delphi/explainers/default/prompts.py
+++ b/delphi/explainers/default/prompts.py
@@ -1,5 +1,28 @@
 ### SYSTEM PROMPT ###
 
+SYSTEM_SINGLE_TOKEN = """Your job is to look for patterns in text. You will be given a list of WORDS, your task is to provide an explanation for what pattern best describes them. Here are some guidelines:
+- Produce a specific final description for the features common in the examples, and what patterns you found.
+- Don't focus on giving examples of important tokens, if the examples are uninformative, you don't need to mention them.
+- Do not make lists of possible explanations. Keep your explanations short and concise.
+- The last line of your response must be the formatted explanation, using [EXPLANATION]:
+
+Here are some example:
+
+WORDS: ['Thomas Edison', 'Steve Jobs', 'Alexander Graham Bell']
+[EXPLANATION]: Names of people who are inventors of technical fields
+
+WORDS: ['over the moon', 'till the cows come home', 'than meets the eye']
+[EXPLANATION]: Common idioms in text conveying positive sentiment.
+
+WORDS: ['er', 'er', 'er']
+[EXPLANATION]: The token "er".
+
+WORDS: ['house', 'a box', 'smoking area', 'way']
+[EXPLANATION]: Nouns representing a distinct objects that contains something, sometimes preciding a quotation mark.
+
+{prompt}
+"""
+
 SYSTEM = """You are a meticulous AI researcher conducting an important investigation into patterns found in language. Your task is to analyze text and provide an explanation that thoroughly encapsulates possible patterns found in it.
 Guidelines:
 
@@ -204,5 +227,13 @@ def system(cot=False):
         {
             "role": "system",
             "content": SYSTEM.format(prompt=prompt),
+        }
+    ]
+
+def system_single_token():
+    return [    
+        {
+            "role": "system",
+            "content": SYSTEM_SINGLE_TOKEN
         }
     ]

--- a/delphi/explainers/single_token_explainer.py
+++ b/delphi/explainers/single_token_explainer.py
@@ -1,0 +1,117 @@
+import re
+import asyncio
+
+from delphi.explainers.explainer import Explainer, ExplainerResult
+from delphi.explainers.default.prompt_builder import build_single_token_prompt
+from delphi.logger import logger
+
+class SingleTokenExplainer(Explainer):
+    name = "single_token"
+
+    def __init__(
+        self,
+        client,
+        tokenizer,
+        verbose: bool = False,
+        activations: bool = False,
+        cot: bool = False,
+        threshold: float = 0.6,
+        temperature: float = 0.,
+        **generation_kwargs,
+    ):
+        self.client = client
+        self.tokenizer = tokenizer
+        self.verbose = verbose
+
+        self.activations = activations
+        self.cot = cot
+        self.threshold = threshold
+        self.temperature = temperature
+        self.generation_kwargs = generation_kwargs
+
+    async def __call__(self, record):
+
+        messages = self._build_prompt(record.train)
+        
+        response = await self.client.generate(
+            messages, temperature=self.temperature, **self.generation_kwargs
+        )
+
+        try:
+            explanation = self.parse_explanation(response.text)
+            if self.verbose:
+                return (
+                    messages[-1]["content"],
+                    response,
+                    ExplainerResult(record=record, explanation=explanation),
+                )
+
+            return ExplainerResult(record=record, explanation=explanation)
+        except Exception as e:
+            logger.error(f"Explanation parsing failed: {e}")
+            return ExplainerResult(record=record, explanation="Explanation could not be parsed.")
+
+    def parse_explanation(self, text: str) -> str:
+        try:
+            match = re.search(r"\[EXPLANATION\]:\s*(.*)", text, re.DOTALL)
+            return match.group(1).strip() if match else "Explanation could not be parsed."
+        except Exception as e:
+            logger.error(f"Explanation parsing regex failed: {e}")
+            raise
+
+    def _highlight(self, index, example):
+        # result = f"Example {index}: "
+        result = f""
+        threshold = example.max_activation * self.threshold
+        if self.tokenizer is not None:
+            str_toks = self.tokenizer.batch_decode(example.tokens)
+            example.str_toks = str_toks
+        else:
+            str_toks = example.tokens
+            example.str_toks = str_toks
+        activations = example.activations
+
+        def check(i):
+            return activations[i] > threshold
+
+        i = 0
+        while i < len(str_toks):
+            if check(i):
+                # result += "<<"
+
+                while i < len(str_toks) and check(i):
+                    result += str_toks[i]
+                    i += 1
+                # result += ">>"
+            else:
+                # result += str_toks[i]
+                i += 1
+
+        return "".join(result)
+
+    def _join_activations(self, example):
+        activations = []
+
+        for i, activation in enumerate(example.activations):
+            if activation > example.max_activation * self.threshold:
+                activations.append((example.str_toks[i], int(example.normalized_activations[i])))
+
+        acts = ", ".join(f'("{item[0]}" : {item[1]})' for item in activations)
+
+        return "Activations: " + acts
+
+    def _build_prompt(self, examples):
+        highlighted_examples = []
+
+        for i, example in enumerate(examples):
+            highlighted_examples.append(self._highlight(i + 1, example))
+
+            if self.activations:
+                highlighted_examples.append(self._join_activations(example))
+
+        return build_single_token_prompt(
+            examples=highlighted_examples,
+        )
+
+    def call_sync(self, record):
+        return asyncio.run(self.__call__(record))

--- a/delphi/features/__init__.py
+++ b/delphi/features/__init__.py
@@ -2,7 +2,7 @@ from .cache import FeatureCache
 from .constructors import (
     default_constructor,
     pool_max_activation_windows,
-    random_activation_windows,
+    random_non_activating_windows,
 )
 from .features import Example, Feature, FeatureRecord
 from .loader import FeatureDataset, FeatureLoader
@@ -16,7 +16,7 @@ __all__ = [
     "FeatureRecord",
     "Example",
     "pool_max_activation_windows",
-    "random_activation_windows",
+    "random_non_activating_windows",
     "default_constructor",
     "sample",
     "get_neighbors",

--- a/delphi/features/constructors.py
+++ b/delphi/features/constructors.py
@@ -76,7 +76,7 @@ def pool_max_activation_windows(
     record.examples = prepare_examples(token_windows, activation_windows)
 
 def random_activation_windows(
-    record,
+    record: FeatureRecord,
     tokens: TensorType["batch", "seq"],
     buffer_output: BufferOutput,
     ctx_len: int,

--- a/delphi/features/constructors.py
+++ b/delphi/features/constructors.py
@@ -94,6 +94,7 @@ def random_activation_windows(
     """
     torch.manual_seed(22)
     if n_random == 0:
+        record.random_examples = []
         return
     batch_size = tokens.shape[0]
     unique_batch_pos = buffer_output.locations[:, 0].unique()

--- a/delphi/features/features.py
+++ b/delphi/features/features.py
@@ -95,7 +95,7 @@ class FeatureRecord:
         """
         self.feature = feature
         self.examples = []
-        self.random_examples = []
+        self.negative_examples = []
         self.train: list[list[Example]] = []
         self.test: list[list[Example]] = []
 

--- a/delphi/features/features.py
+++ b/delphi/features/features.py
@@ -95,6 +95,7 @@ class FeatureRecord:
         """
         self.feature = feature
         self.examples = []
+        self.random_examples = []
         self.train: list[list[Example]] = []
         self.test: list[list[Example]] = []
 

--- a/delphi/features/features.py
+++ b/delphi/features/features.py
@@ -94,8 +94,8 @@ class FeatureRecord:
             feature (Feature): The feature associated with the record.
         """
         self.feature = feature
-        self.examples = []
-        self.negative_examples = []
+        self.examples: list[Example] = []
+        self.not_active: list[Example] = []
         self.train: list[list[Example]] = []
         self.test: list[list[Example]] = []
 

--- a/delphi/features/loader.py
+++ b/delphi/features/loader.py
@@ -147,7 +147,8 @@ class FeatureDataset:
         if features is None:
             self._build(raw_dir, modules)
         else:
-            self._build_selected(raw_dir, modules, features)
+            # TODO fix type error
+            self._build_selected(raw_dir, modules, features) # type: ignore
 
         cache_config_dir = f"{raw_dir}/{modules[0]}/config.json"
         with open(cache_config_dir, "r") as f:

--- a/delphi/scorers/classifier/classifier.py
+++ b/delphi/scorers/classifier/classifier.py
@@ -58,7 +58,7 @@ class Classifier(Scorer):
         self,
         explanation: str,
         batches: list[list[Sample]],
-    ) -> list[Sample]:
+    ) -> list[ClassifierOutput]:
         """
         Send and gather batches of samples to the model.
         """
@@ -92,30 +92,30 @@ class Classifier(Scorer):
             logger.error(f"Error generating text: {e}")
             response = None
         if response is None:
-            array = [-1] * self.batch_size
+            predictions = [-1] * self.batch_size
             probabilities = [-1] * self.batch_size
         else:
             selections = response.text
             logprobs = response.logprobs if self.log_prob else None
             try:
-                array, probabilities = self._parse(selections, logprobs)
+                predictions, probabilities = self._parse(selections, logprobs)
             except Exception as e:
                 logger.error(f"Parsing selections failed: {e}")
-                array = [-1] * self.batch_size
+                predictions = [-1] * self.batch_size
                 probabilities = [-1] * self.batch_size
 
         results = []
         correct = []
         response = []
-        for i, sample in enumerate(batch):
+
+        for sample, prediction, probability in zip(batch, predictions, probabilities):
             result = sample.data
-            prediction = array[i] 
             result.prediction = prediction
             result.correct = prediction == result.ground_truth
             correct.append(result.ground_truth)
             response.append(prediction)
-            if self.log_prob:
-                result.probability = probabilities[i]
+            if probability is not None:
+                result.probability = probability
             results.append(result)
 
             if self.verbose:
@@ -124,35 +124,41 @@ class Classifier(Scorer):
 
     
     def _parse(self, string, logprobs=None):
+        """Extract binary predictions and probabilities from a string and 
+        optionally its token logprobs."""
+        # Matches the first instance of text enclosed in square brackets
         pattern = r"\[.*?\]"
         match = re.search(pattern, string)
 
-        try:
-            array = json.loads(match.group(0))
-            assert len(array) == self.batch_size
-            if self.log_prob:
-                probabilities = self._parse_logprobs(logprobs)
-                assert len(probabilities) == self.batch_size
-                return array, probabilities
-            probabilities = None
-            return array, probabilities
-        except (json.JSONDecodeError, AssertionError, AttributeError) as e:
-            logger.error(f"Parsing array failed: {e}")
-            if self.log_prob:
-                return [-1] * self.batch_size, [-1] * self.batch_size
-            return [-1] * self.batch_size
+        predictions: list[int] = json.loads(match.group(0))
+        assert len(predictions) == self.batch_size
+        probabilities = (
+            self._parse_logprobs(logprobs)
+            if logprobs is not None
+            else [None] * self.batch_size
+        )
 
-    def _parse_logprobs(self, logprobs):
-        #Logprobs will be a list of 5 probabilites for each token in the response
-        # The response will be in the form of [x, x, x, ...] for each position we
-        # need to get the probability of 1 or 0 
-        probabilities = []
+        return predictions, probabilities
+
+
+    def _parse_logprobs(self, logprobs: list):
+        """
+        Extracts normalized probabilities of '1' vs '0' tokens from the top n log probabilities for each 
+        token in a response string of form '[x, x, x, ...]'. The normalized probability is computed as 
+        P(1)/(P(0) + P(1)), where P(0) and P(1) are summed over all matching tokens in the top 5 candidates.
+
+        Args:
+            logprobs (list): Contains top n log probabilities for each token in the response.
+
+        Returns:
+            list: Normalized probabilities between 0 and 1, where each value represents P(token='1')."""
+        binary_probabilities: list[float] = []
         
         for i in range(len(logprobs)):
             if "1" in logprobs[i].token or "0" in logprobs[i].token:
                 top_logprobs = logprobs[i].top_logprobs
-                prob_0 = 0
-                prob_1 = 0
+                prob_0 = 0.
+                prob_1 = 0.
                 for i in range(len(top_logprobs)):
                     token = top_logprobs[i].token
                     logprob = top_logprobs[i].logprob
@@ -160,11 +166,13 @@ class Classifier(Scorer):
                         prob_0 += np.exp(logprob).item()
                     elif "1" in token:
                         prob_1 += np.exp(logprob).item()
-                if prob_0+prob_1>0:
-                    probabilities.append(prob_1/(prob_0+prob_1))
+                if prob_0 + prob_1 > 0:
+                    binary_probabilities.append(prob_1 / (prob_0 + prob_1))
                 else:
-                    probabilities.append(0)
-        return probabilities
+                    binary_probabilities.append(0.)
+
+        assert len(binary_probabilities) == self.batch_size
+        return binary_probabilities
 
 
     def _build_prompt(

--- a/delphi/scorers/classifier/detection.py
+++ b/delphi/scorers/classifier/detection.py
@@ -17,6 +17,7 @@ class DetectionScorer(Classifier):
         verbose: bool = False,
         batch_size: int = 10,
         log_prob: bool = False,
+        temperature: float = 0.,
         **generation_kwargs,
     ):
         super().__init__(
@@ -25,6 +26,7 @@ class DetectionScorer(Classifier):
             verbose=verbose,
             batch_size=batch_size,
             log_prob=log_prob,
+            temperature=temperature,
             **generation_kwargs,
         )
 

--- a/delphi/scorers/classifier/detection.py
+++ b/delphi/scorers/classifier/detection.py
@@ -38,7 +38,7 @@ class DetectionScorer(Classifier):
         """
 
         samples = examples_to_samples(
-            record.random_examples,
+            record.negative_examples,
             distance=-1,
             ground_truth=False,
             tokenizer=self.tokenizer,

--- a/delphi/scorers/classifier/detection.py
+++ b/delphi/scorers/classifier/detection.py
@@ -38,7 +38,7 @@ class DetectionScorer(Classifier):
         """
 
         samples = examples_to_samples(
-            record.negative_examples,
+            record.not_active,
             distance=-1,
             ground_truth=False,
             tokenizer=self.tokenizer,

--- a/delphi/scorers/classifier/fuzz.py
+++ b/delphi/scorers/classifier/fuzz.py
@@ -24,6 +24,7 @@ class FuzzingScorer(Classifier, Scorer):
         batch_size: int = 1,
         threshold: float = 0.3,
         log_prob: bool = False,
+        temperature: float = 0.,
         **generation_kwargs,
     ):
         super().__init__(
@@ -32,6 +33,7 @@ class FuzzingScorer(Classifier, Scorer):
             verbose=verbose,
             batch_size=batch_size,
             log_prob=log_prob,
+            temperature=temperature,
             **generation_kwargs,
         )
 

--- a/delphi/scorers/simulator/oai_simulator.py
+++ b/delphi/scorers/simulator/oai_simulator.py
@@ -40,8 +40,8 @@ class OpenAISimulator(Scorer):
         )
 
         valid_activation_records = self.to_activation_records(record.test)
-        if len(record.negative_examples) > 0:
-            non_activation_records = self.to_activation_records([record.negative_examples])
+        if len(record.not_active) > 0:
+            non_activation_records = self.to_activation_records([record.not_active])
         else:
             non_activation_records = []
 

--- a/delphi/scorers/simulator/oai_simulator.py
+++ b/delphi/scorers/simulator/oai_simulator.py
@@ -40,8 +40,8 @@ class OpenAISimulator(Scorer):
         )
 
         valid_activation_records = self.to_activation_records(record.test)
-        if len(record.random_examples) > 0:
-            non_activation_records = self.to_activation_records([record.random_examples])
+        if len(record.negative_examples) > 0:
+            non_activation_records = self.to_activation_records([record.negative_examples])
         else:
             non_activation_records = []
 

--- a/delphi/tests/e2e.py
+++ b/delphi/tests/e2e.py
@@ -107,7 +107,7 @@ async def test():
         max_features=100,
         seed=22,
         num_gpus=torch.cuda.device_count(),
-        filter_tokens=None
+        filter_bos=True
     )
 
     start_time = time.time()

--- a/delphi/tests/e2e.py
+++ b/delphi/tests/e2e.py
@@ -5,39 +5,95 @@ from torch import Tensor
 import pandas as pd
 import asyncio
 import time
+import numpy as np
+
 
 from delphi.config import ExperimentConfig, FeatureConfig, CacheConfig
-from delphi.__main__ import run, RunConfig, load_artifacts
-
+from delphi.__main__ import run, RunConfig
 
 def parse_score_file(file_path):
     with open(file_path, "rb") as f:
         data = orjson.loads(f.read())
-
-    return pd.DataFrame(
-        [
-            {
-                "text": "".join(example["str_tokens"]),
-                "distance": example["distance"],
-                "ground_truth": example["ground_truth"],
-                "prediction": example["prediction"],
-                "probability": example["probability"],
-                "correct": example["correct"],
-                "activations": example["activations"],
-                "highlighted": example["highlighted"],
-            }
-            for example in data
-        ]
-    )
+    
+    df = pd.DataFrame([{
+        "text": "".join(example["str_tokens"]),
+        "distance": example["distance"],
+        "ground_truth": example["ground_truth"],
+        "prediction": example["prediction"],
+        "probability": example["probability"],
+        "correct": example["correct"],
+        "activations": example["activations"],
+        "highlighted": example["highlighted"]
+    } for example in data])
+    
+    # Calculate basic counts
+    failed_count = (df['prediction'] == -1).sum()
+    df = df[df['prediction'] != -1]
+    df.reset_index(drop=True, inplace=True)
+    total_examples = len(df)
+    total_positives = (df["ground_truth"]).sum()
+    total_negatives = (~df["ground_truth"]).sum()
+    
+    # Calculate confusion matrix elements
+    true_positives = ((df["prediction"] == 1) & (df["ground_truth"])).sum()
+    true_negatives = ((df["prediction"] == 0) & (~df["ground_truth"])).sum()
+    false_positives = ((df["prediction"] == 1) & (~df["ground_truth"])).sum()
+    false_negatives = ((df["prediction"] == 0) & (df["ground_truth"])).sum()
+    
+    # Calculate rates
+    true_positive_rate = true_positives / total_positives if total_positives > 0 else 0
+    true_negative_rate = true_negatives / total_negatives if total_negatives > 0 else 0
+    false_positive_rate = false_positives / total_negatives if total_negatives > 0 else 0
+    false_negative_rate = false_negatives / total_positives if total_positives > 0 else 0
+    
+    # Calculate precision, recall, f1 (using sklearn for verification)
+    precision = true_positives / (true_positives + false_positives) if (true_positives + false_positives) > 0 else 0
+    recall = true_positive_rate  # Same as TPR
+    f1_score = 2 * (precision * recall) / (precision + recall) if (precision + recall) > 0 else 0
+    
+    # Calculate accuracy
+    accuracy = (true_positives + true_negatives) / total_examples
+    
+    # Add metrics to first row
+    metrics = {
+        "true_positive_rate": true_positive_rate,
+        "true_negative_rate": true_negative_rate,
+        "false_positive_rate": false_positive_rate,
+        "false_negative_rate": false_negative_rate,
+        "true_positives": true_positives,
+        "true_negatives": true_negatives,
+        "false_positives": false_positives,
+        "false_negatives": false_negatives,
+        "precision": precision,
+        "recall": recall,
+        "f1_score": f1_score,
+        "accuracy": accuracy,
+        "total_examples": total_examples,
+        "total_positives": total_positives,
+        "total_negatives": total_negatives,
+        "positive_class_ratio": total_positives / total_examples,
+        "negative_class_ratio": total_negatives / total_examples,
+        "failed_count": failed_count,
+    }
+    
+    for key, value in metrics.items():
+        df.loc[0, key] = value
+    
+    return df
 
 
 def build_df(path: Path, target_modules: list[str], range: Tensor | None):
-    accuracies = []
-    probabilities = []
-    score_types = []
-    file_names = []
-    feature_indices = []
-    modules = []
+    metrics_cols = [
+        "accuracy", "probability", "precision", "recall", "f1_score",
+        "true_positives", "true_negatives", "false_positives", "false_negatives",
+        "true_positive_rate", "true_negative_rate", "false_positive_rate", "false_negative_rate",
+        "total_examples", "total_positives", "total_negatives",
+        "positive_class_ratio", "negative_class_ratio", "failed_count"
+    ]
+    df_data = {
+        col: [] 
+        for col in ["file_name", "score_type", "feature_idx", "module"] + metrics_cols
+    }
 
     # Get subdirectories in the scores path
     scores_types = [d.name for d in path.iterdir() if d.is_dir()]
@@ -55,23 +111,14 @@ def build_df(path: Path, target_modules: list[str], range: Tensor | None):
                 df = parse_score_file(score_file)
 
                 # Calculate the accuracy and cross entropy loss for this feature
-                file_names.append(score_file.stem)
-                score_types.append(score_type)
-                feature_indices.append(feature_idx)
-                accuracies.append(df["correct"].mean())
-                probabilities.append(df["probability"].mean())
-                modules.append(module)
+                df_data["file_name"].append(score_file.stem)
+                df_data["score_type"].append(score_type)
+                df_data["feature_idx"].append(feature_idx)
+                df_data["module"].append(module)
+                for col in metrics_cols: df_data[col].append(df.loc[0, col])
 
-    df = pd.DataFrame(
-        {
-            "file_name": file_names,
-            "score_type": score_types,
-            "feature_idx": feature_indices,
-            "accuracy": accuracies,
-            "probability": probabilities,
-            "module": modules,
-        }
-    )
+
+    df = pd.DataFrame(df_data)
     assert not df.empty
     return df
 
@@ -124,8 +171,51 @@ async def test():
 
     # Performs better than random guessing
     for score_type in df["score_type"].unique():
-        print(df[df['score_type'] == score_type]["accuracy"].mean())
-        assert df[df['score_type'] == score_type]["accuracy"].mean() > 0.54, f"Score type {score_type} has an accuracy of {df[df['score_type'] == score_type]['accuracy'].mean()}"
+        score_df = df[df['score_type'] == score_type]
+        # Calculate weights based on non-errored examples
+        valid_examples = score_df['total_examples']
+        weights = valid_examples / valid_examples.sum()
+
+        weighted_mean_metrics = {
+            'accuracy': np.average(score_df['accuracy'], weights=weights),
+            'f1_score': np.average(score_df['f1_score'], weights=weights),
+            'precision': np.average(score_df['precision'], weights=weights),
+            'recall': np.average(score_df['recall'], weights=weights),
+            'false_positives': np.average(score_df['false_positives'], weights=weights),
+            'false_negatives': np.average(score_df['false_negatives'], weights=weights),
+            'true_positives': np.average(score_df['true_positives'], weights=weights),
+            'true_negatives': np.average(score_df['true_negatives'], weights=weights),
+            'positive_class_ratio': np.average(score_df['positive_class_ratio'], weights=weights),
+            'negative_class_ratio': np.average(score_df['negative_class_ratio'], weights=weights),
+            'total_positives': np.average(score_df['total_positives'], weights=weights),
+            'total_negatives': np.average(score_df['total_negatives'], weights=weights),
+            'true_positive_rate': np.average(score_df['true_positive_rate'], weights=weights),
+            'true_negative_rate': np.average(score_df['true_negative_rate'], weights=weights),
+            'false_positive_rate': np.average(score_df['false_positive_rate'], weights=weights),
+            'false_negative_rate': np.average(score_df['false_negative_rate'], weights=weights),
+        }
+
+        print(f"\n=== {score_type.title()} Metrics ===")
+        print(f"Accuracy: {weighted_mean_metrics['accuracy']:.3f}")
+        print(f"F1 Score: {weighted_mean_metrics['f1_score']:.3f}")
+        print(f"Precision: {weighted_mean_metrics['precision']:.3f}")
+        print(f"Recall: {weighted_mean_metrics['recall']:.3f}")
+
+        fractions_failed = [failed_count / total_examples for failed_count, total_examples in zip(score_df['failed_count'], score_df['total_examples'])]
+        print(f"Average fraction of failed examples: {sum(fractions_failed) / len(fractions_failed):.3f}")
+
+        print("\nConfusion Matrix:")
+        print(f"True Positive Rate:  {weighted_mean_metrics['true_positive_rate']:.3f}")
+        print(f"True Negative Rate:  {weighted_mean_metrics['true_negative_rate']:.3f}")
+        print(f"False Positive Rate: {weighted_mean_metrics['false_positive_rate']:.3f}")
+        print(f"False Negative Rate: {weighted_mean_metrics['false_negative_rate']:.3f}")
+        
+        print(f"\nClass Distribution:")
+        print(f"Positives: {score_df['total_positives'].sum():.0f} ({weighted_mean_metrics['positive_class_ratio']:.1%})")
+        print(f"Negatives: {score_df['total_negatives'].sum():.0f} ({weighted_mean_metrics['negative_class_ratio']:.1%})")
+        print(f"Total: {score_df['total_examples'].sum():.0f}")
+
+        assert weighted_mean_metrics['accuracy'] > 0.55, f"Score type {score_type} has an accuracy of {weighted_mean_metrics['accuracy']}"
 
 
 if __name__ == "__main__":

--- a/examples/example_script.py
+++ b/examples/example_script.py
@@ -82,7 +82,7 @@ def main(args):
     def scorer_preprocess(result):
         record = result.record
         record.explanation = result.explanation
-        record.extra_examples = record.random_examples
+        record.extra_examples = record.negative_examples
 
         return record
 

--- a/examples/score_explanations.ipynb
+++ b/examples/score_explanations.ipynb
@@ -160,7 +160,7 @@
     "def scorer_preprocess(result):\n",
     "        record = result.record   \n",
     "        record.explanation = result.explanation\n",
-    "        record.extra_examples = record.negative_examples\n",
+    "        record.extra_examples = record.not_active\n",
     "\n",
     "        return record\n",
     "\n",

--- a/examples/score_explanations.ipynb
+++ b/examples/score_explanations.ipynb
@@ -160,7 +160,7 @@
     "def scorer_preprocess(result):\n",
     "        record = result.record   \n",
     "        record.explanation = result.explanation\n",
-    "        record.extra_examples = record.random_examples\n",
+    "        record.extra_examples = record.negative_examples\n",
     "\n",
     "        return record\n",
     "\n",

--- a/examples/server.py
+++ b/examples/server.py
@@ -136,7 +136,7 @@ def generate_score_fuzz_detection():
         feature_record = FeatureRecord(feature)
         feature_record.test = [activating_examples]
         feature_record.extra_examples = non_activating_examples
-        feature_record.random_examples = non_activating_examples
+        feature_record.negative_examples = non_activating_examples
         feature_record.explanation = data['explanation']
         
         client = OpenRouter(api_key=data['api_key'], model=data['model'])
@@ -183,7 +183,7 @@ def generate_score_embedding():
         feature_record = FeatureRecord(feature)
         feature_record.test = [activating_examples]
         feature_record.extra_examples = non_activating_examples
-        feature_record.random_examples = non_activating_examples
+        feature_record.negative_examples = non_activating_examples
         feature_record.explanation = data['explanation']
         scorer =  EmbeddingScorer(model)
         result = scorer.call_sync(feature_record)  # Use call_sync instead of __call__

--- a/examples/server.py
+++ b/examples/server.py
@@ -136,7 +136,7 @@ def generate_score_fuzz_detection():
         feature_record = FeatureRecord(feature)
         feature_record.test = [activating_examples]
         feature_record.extra_examples = non_activating_examples
-        feature_record.negative_examples = non_activating_examples
+        feature_record.not_active = non_activating_examples
         feature_record.explanation = data['explanation']
         
         client = OpenRouter(api_key=data['api_key'], model=data['model'])

--- a/experiments/caching_gemma/embedding.py
+++ b/experiments/caching_gemma/embedding.py
@@ -68,7 +68,7 @@ def main(args):
         record = result.record
         
         record.explanation = result.explanation
-        record.extra_examples = record.negative_examples
+        record.extra_examples = record.not_active
 
 
         return record

--- a/experiments/caching_gemma/embedding.py
+++ b/experiments/caching_gemma/embedding.py
@@ -68,7 +68,7 @@ def main(args):
         record = result.record
         
         record.explanation = result.explanation
-        record.extra_examples = record.random_examples
+        record.extra_examples = record.negative_examples
 
 
         return record

--- a/experiments/caching_gemma/generate_explanations_and_scores.py
+++ b/experiments/caching_gemma/generate_explanations_and_scores.py
@@ -87,7 +87,7 @@ def main(args):
     def scorer_preprocess(result):
         record = result.record
         record.explanation = result.explanation
-        record.extra_examples = record.negative_examples
+        record.extra_examples = record.not_active
 
         return record
 

--- a/experiments/caching_gemma/generate_explanations_and_scores.py
+++ b/experiments/caching_gemma/generate_explanations_and_scores.py
@@ -87,7 +87,7 @@ def main(args):
     def scorer_preprocess(result):
         record = result.record
         record.explanation = result.explanation
-        record.extra_examples = record.random_examples
+        record.extra_examples = record.negative_examples
 
         return record
 

--- a/experiments/caching_gemma/score_explanations.py
+++ b/experiments/caching_gemma/score_explanations.py
@@ -78,7 +78,7 @@ def main(args):
         record = result.record
         
         record.explanation = result.explanation
-        record.extra_examples = record.negative_examples
+        record.extra_examples = record.not_active
 
         return record
 

--- a/experiments/caching_gemma/score_explanations.py
+++ b/experiments/caching_gemma/score_explanations.py
@@ -78,7 +78,7 @@ def main(args):
         record = result.record
         
         record.explanation = result.explanation
-        record.extra_examples = record.random_examples
+        record.extra_examples = record.negative_examples
 
         return record
 

--- a/experiments/caching_gemma/score_explanations_fig1.py
+++ b/experiments/caching_gemma/score_explanations_fig1.py
@@ -91,7 +91,7 @@ def main(args):
         record = result.record
         
         record.explanation = result.explanation
-        record.extra_examples = record.random_examples
+        record.extra_examples = record.negative_examples
 
         return record
 

--- a/experiments/caching_gemma/score_explanations_fig1.py
+++ b/experiments/caching_gemma/score_explanations_fig1.py
@@ -91,7 +91,7 @@ def main(args):
         record = result.record
         
         record.explanation = result.explanation
-        record.extra_examples = record.negative_examples
+        record.extra_examples = record.not_active
 
         return record
 

--- a/experiments/caching_gemma/surprisal.py
+++ b/experiments/caching_gemma/surprisal.py
@@ -64,7 +64,7 @@ def main(args):
         record = result.record
         
         record.explanation = result.explanation
-        record.extra_examples = record.negative_examples
+        record.extra_examples = record.not_active
 
 
         return record

--- a/experiments/caching_gemma/surprisal.py
+++ b/experiments/caching_gemma/surprisal.py
@@ -64,7 +64,7 @@ def main(args):
         record = result.record
         
         record.explanation = result.explanation
-        record.extra_examples = record.random_examples
+        record.extra_examples = record.negative_examples
 
 
         return record

--- a/experiments/caching_llama/generate_explanations_and_scores.py
+++ b/experiments/caching_llama/generate_explanations_and_scores.py
@@ -87,7 +87,7 @@ def main(args):
     def scorer_preprocess(result):
         record = result.record
         record.explanation = result.explanation
-        record.extra_examples = record.negative_examples
+        record.extra_examples = record.not_active
 
         return record
 

--- a/experiments/caching_llama/generate_explanations_and_scores.py
+++ b/experiments/caching_llama/generate_explanations_and_scores.py
@@ -87,7 +87,7 @@ def main(args):
     def scorer_preprocess(result):
         record = result.record
         record.explanation = result.explanation
-        record.extra_examples = record.random_examples
+        record.extra_examples = record.negative_examples
 
         return record
 

--- a/experiments/caching_llama/score_explanations.py
+++ b/experiments/caching_llama/score_explanations.py
@@ -83,7 +83,7 @@ def main(args):
         record = result.record
         
         record.explanation = result.explanation
-        record.extra_examples = record.random_examples
+        record.extra_examples = record.negative_examples
 
         return record
 

--- a/experiments/caching_llama/score_explanations.py
+++ b/experiments/caching_llama/score_explanations.py
@@ -83,7 +83,7 @@ def main(args):
         record = result.record
         
         record.explanation = result.explanation
-        record.extra_examples = record.negative_examples
+        record.extra_examples = record.not_active
 
         return record
 

--- a/experiments/caching_llama/surprisal.py
+++ b/experiments/caching_llama/surprisal.py
@@ -62,7 +62,7 @@ def main(args):
         record = result.record
         
         record.explanation = result.explanation
-        record.extra_examples = record.random_examples
+        record.extra_examples = record.negative_examples
 
 
         return record

--- a/experiments/caching_llama/surprisal.py
+++ b/experiments/caching_llama/surprisal.py
@@ -62,7 +62,7 @@ def main(args):
         record = result.record
         
         record.explanation = result.explanation
-        record.extra_examples = record.negative_examples
+        record.extra_examples = record.not_active
 
 
         return record


### PR DESCRIPTION
- Add single token explainer
- Update comments for some ambiguous config options
- Fix bug where n_random=0 triggers an error
- Fix types
- Set temp to 0 for single shot generations (default, fuzz, detection)
- Renamed n_random and random_activating_windows to n_negative and random_non_activating_windows since I think they're to collect negative/non-activating examples
- Add an example of correct -1 score filtering and data analysis to e2e test
- Simplify filter_tokens option in the run config to filter_bos 