### PR TITLE
Cleaning up cache, latent loader and adding tests

### DIFF
--- a/delphi/__main__.py
+++ b/delphi/__main__.py
@@ -240,7 +240,6 @@ def populate_cache(
     cache = LatentCache(
         model,
         hookpoint_to_sae_encode,
-        width=latent_cfg.width,
         batch_size=cfg.batch_size,
     )
     cache.run(cfg.n_tokens, tokens)

--- a/delphi/__main__.py
+++ b/delphi/__main__.py
@@ -26,7 +26,7 @@ from transformers import (
 from delphi.clients import Offline, OpenRouter
 from delphi.config import CacheConfig, ExperimentConfig, LatentConfig, RunConfig
 from delphi.explainers import DefaultExplainer
-from delphi.latents import LatentCache, LatentDataset, LatentLoader
+from delphi.latents import LatentCache, LatentDataset
 from delphi.latents.constructors import default_constructor
 from delphi.latents.samplers import sample
 from delphi.log.result_analysis import log_results
@@ -135,7 +135,7 @@ async def process_cache(
         max_examples=latent_cfg.max_examples,
     )
     sampler = partial(sample, cfg=experiment_cfg)
-    loader = LatentLoader(dataset, constructor=constructor, sampler=sampler)
+    dataset.build_iterator(constructor, sampler, None)
 
     def explainer_postprocess(result):
         with open(explanations_path / f"{result.record.latent}.txt", "wb") as f:
@@ -191,7 +191,7 @@ async def process_cache(
     )
 
     pipeline = Pipeline(
-        loader,
+        dataset,
         explainer_pipe,
         scorer_pipe,
     )

--- a/delphi/__main__.py
+++ b/delphi/__main__.py
@@ -220,7 +220,7 @@ def populate_cache(
     )
     data = data.shuffle(run_cfg.seed)
     data = chunk_and_tokenize(
-        data, tokenizer, max_seq_len=cfg.ctx_len, text_key=cfg.dataset_row
+        data, tokenizer, max_seq_len=cfg.ctx_len, text_key=cfg.dataset_column_name
     )
     tokens = data["input_ids"]
 

--- a/delphi/config.py
+++ b/delphi/config.py
@@ -143,7 +143,7 @@ class RunConfig:
     and 'visualize'."""
 
     num_examples_per_scorer_prompt: int = field(
-        default=1,
+        default=5,
     )
     """Number of examples to use for each scorer prompt. Using more than 1 improves
     scoring speed but can leak information to the fuzzing and detection scorer,

--- a/delphi/config.py
+++ b/delphi/config.py
@@ -32,9 +32,6 @@ class ExperimentConfig(Serializable):
 
 @dataclass
 class LatentConfig(Serializable):
-    width: int = 131_072
-    """Number of latents in each autoencoder"""
-
     min_examples: int = 200
     """Minimum number of examples to generate for a single latent.
     If the number of activating examples is less than this, the
@@ -42,9 +39,6 @@ class LatentConfig(Serializable):
 
     max_examples: int = 10_000
     """Maximum number of examples to generate for a single latent."""
-
-    n_splits: int = 5
-    """Number of splits that latents will be divided into."""
 
 
 @dataclass

--- a/delphi/config.py
+++ b/delphi/config.py
@@ -52,7 +52,7 @@ class CacheConfig(Serializable):
     dataset_name: str = ""
     """Dataset name to use."""
 
-    dataset_row: str = "raw_content"
+    dataset_column_name: str = "raw_content"
     """Dataset row to use."""
 
     batch_size: int = 32

--- a/delphi/latents/__init__.py
+++ b/delphi/latents/__init__.py
@@ -5,7 +5,7 @@ from .constructors import (
     random_non_activating_windows,
 )
 from .latents import Example, Latent, LatentRecord
-from .loader import LatentDataset, LatentLoader
+from .loader import LatentDataset
 from .samplers import sample
 from .stats import get_neighbors, unigram
 
@@ -21,5 +21,4 @@ __all__ = [
     "sample",
     "get_neighbors",
     "unigram",
-    "LatentLoader",
 ]

--- a/delphi/latents/loader.py
+++ b/delphi/latents/loader.py
@@ -126,6 +126,9 @@ class LatentDataset:
         tokenizer: Optional[Callable] = None,
         modules: Optional[list[str]] = None,
         latents: Optional[dict[str, Union[int, torch.Tensor]]] = None,
+        constructor: Optional[Callable] = None,
+        sampler: Optional[Callable] = None,
+        transform: Optional[Callable] = None,
     ):
         """
         Initialize a LatentDataset.
@@ -155,6 +158,9 @@ class LatentDataset:
         else:
             self.tokenizer = tokenizer
         self.cache_config = cache_config
+        self.constructor = constructor
+        self.sampler = sampler
+        self.transform = transform
 
     def load_tokens(self):
         """
@@ -259,14 +265,6 @@ class LatentDataset:
         """Reset all buffers in the dataset."""
         for buffer in self.buffers:
             buffer.reset()
-
-    def build_iterator(
-        self, constructor: Callable, sampler: Callable, transform: Callable
-    ):
-        """Build an iterator for the dataset."""
-        self.constructor = constructor
-        self.sampler = sampler
-        self.transform = transform
 
     def __iter__(self):
         """

--- a/delphi/tests/conftest.py
+++ b/delphi/tests/conftest.py
@@ -6,19 +6,22 @@ from delphi.config import CacheConfig, RunConfig
 from delphi.latents import LatentCache
 from delphi.sparse_coders import load_sparse_coders
 
-random_text = ["Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-                "Suspendisse dapibus elementum tellus, ut efficitur lorem fringilla",
-                "consequat. Curabitur luctus iaculis cursus. Aliquam erat volutpat.",
-                "Nam porttitor vulputate arcu, nec rutrum magna malesuada eget.",
-                "Vivamus ultrices lacus quam, quis malesuada augue iaculis et.",
-                "Proin a egestas urna, ac sollicitudin orci. Suspendisse sem mi,",
-                "vulputate vitae egestas sed, ullamcorper vel arcu.",
-                "Phasellus in ornare tellus.Fusce bibendum purus dolor,",
-                "quis ornare sem congue eget.",
-                "Aenean et lectus nibh. Nunc ac sapien a mauris facilisis",
-                "aliquam sed vitae velit. Sed porttitor a diam id rhoncus.",
-                "Mauris viverra laoreet ex, vitae pulvinar diam pellentesque nec.",
-                "Vivamus quis maximus tellus, vel consectetur lorem."]
+random_text = [
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+    "Suspendisse dapibus elementum tellus, ut efficitur lorem fringilla",
+    "consequat. Curabitur luctus iaculis cursus. Aliquam erat volutpat.",
+    "Nam porttitor vulputate arcu, nec rutrum magna malesuada eget.",
+    "Vivamus ultrices lacus quam, quis malesuada augue iaculis et.",
+    "Proin a egestas urna, ac sollicitudin orci. Suspendisse sem mi,",
+    "vulputate vitae egestas sed, ullamcorper vel arcu.",
+    "Phasellus in ornare tellus.Fusce bibendum purus dolor,",
+    "quis ornare sem congue eget.",
+    "Aenean et lectus nibh. Nunc ac sapien a mauris facilisis",
+    "aliquam sed vitae velit. Sed porttitor a diam id rhoncus.",
+    "Mauris viverra laoreet ex, vitae pulvinar diam pellentesque nec.",
+    "Vivamus quis maximus tellus, vel consectetur lorem.",
+]
+
 
 @pytest.fixture(scope="module")
 def tokenizer():
@@ -26,18 +29,25 @@ def tokenizer():
     tokenizer.pad_token = tokenizer.eos_token
     return tokenizer
 
+
 @pytest.fixture(scope="module")
 def model():
     model = AutoModelForCausalLM.from_pretrained("EleutherAI/pythia-70m")
     return model
 
-@pytest.fixture(scope="module")
-def mock_dataset(tokenizer: AutoTokenizer) -> torch.Tensor:
-    tokens = tokenizer(random_text, return_tensors="pt",truncation=True,max_length=16,padding=True)["input_ids"]
-    return tokens
 
 @pytest.fixture(scope="module")
-def cache_setup(tmp_path_factory, mock_dataset: torch.Tensor, model: AutoModelForCausalLM):
+def mock_dataset(tokenizer: AutoTokenizer) -> torch.Tensor:
+    tokens = tokenizer(
+        random_text, return_tensors="pt", truncation=True, max_length=16, padding=True
+    )["input_ids"]
+    return tokens
+
+
+@pytest.fixture(scope="module")
+def cache_setup(
+    tmp_path_factory, mock_dataset: torch.Tensor, model: AutoModelForCausalLM
+):
     """
     This fixture creates a temporary directory, loads the model,
     initializes the cache, runs the cache once, saves the cache splits

--- a/delphi/tests/conftest.py
+++ b/delphi/tests/conftest.py
@@ -1,0 +1,53 @@
+import pytest
+import torch
+from transformers import AutoModelForCausalLM
+
+from delphi.config import CacheConfig, RunConfig
+from delphi.latents import LatentCache
+from delphi.sparse_coders import load_sparse_coders
+
+
+@pytest.fixture(scope="module")
+def cache_setup(tmp_path_factory):
+    """
+    This fixture creates a temporary directory, loads the model,
+    initializes the cache, runs the cache once, saves the cache splits
+    and configuration, and returns all the relevant objects.
+    """
+    # Create a temporary directory for saving cache files and config
+    temp_dir = tmp_path_factory.mktemp("test_cache")
+
+    # Load model and set run configuration
+    model = AutoModelForCausalLM.from_pretrained("EleutherAI/pythia-70m")
+    run_cfg_gemma = RunConfig(
+        model="EleutherAI/pythia-70m",
+        sparse_model="EleutherAI/sae-pythia-70m-32k",
+        hookpoints=["layers.1"],
+    )
+    hookpoint_to_sae_encode = load_sparse_coders(model, run_cfg_gemma)
+
+    # Define cache config and initialize cache
+    cache_cfg = CacheConfig(batch_size=1, ctx_len=256, n_tokens=1000)
+    cache = LatentCache(model, hookpoint_to_sae_encode, batch_size=cache_cfg.batch_size)
+
+    # Generate mock tokens and run the cache
+    mock_tokens = torch.randint(0, 1000, (4, cache_cfg.ctx_len))
+    cache.run(cache_cfg.n_tokens, mock_tokens)
+
+    # Save splits to temporary directory (the layer key is "gpt_neox.layers.1")
+
+    cache.save_splits(n_splits=5, save_dir=temp_dir, save_tokens=True)
+
+    # Save the cache config
+
+    cache.save_config(temp_dir, cache_cfg, "EleutherAI/pythia-70m")
+
+    dict_to_return = {
+        "cache": cache,
+        "mock_tokens": mock_tokens,
+        "cache_cfg": cache_cfg,
+        "temp_dir": temp_dir,
+    }
+
+    yield dict_to_return
+    dict_to_return.clear()

--- a/delphi/tests/e2e.py
+++ b/delphi/tests/e2e.py
@@ -13,7 +13,7 @@ async def test():
     cache_cfg = CacheConfig(
         dataset_repo="EleutherAI/fineweb-edu-dedup-10b",
         dataset_split="train[:1%]",
-        dataset_row="text",
+        dataset_column_name="text",
         batch_size=8,
         ctx_len=256,
         n_splits=5,

--- a/delphi/tests/e2e.py
+++ b/delphi/tests/e2e.py
@@ -26,7 +26,6 @@ async def test():
         n_examples_test=50,
     )
     latent_cfg = LatentConfig(
-        width=32_768,
         min_examples=200,
         max_examples=10_000,
     )

--- a/delphi/tests/test_features/test_cache.py
+++ b/delphi/tests/test_features/test_cache.py
@@ -1,0 +1,129 @@
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from safetensors.numpy import load_file
+from transformers import AutoModelForCausalLM
+
+from delphi.config import CacheConfig, RunConfig
+from delphi.latents import LatentCache
+from delphi.sparse_coders import load_sparse_coders
+
+
+@pytest.fixture(scope="module")
+def cache_setup(tmp_path_factory):
+    """
+    This fixture creates a temporary directory, loads the model,
+    initializes the cache, runs the cache once, saves the cache splits
+    and configuration, and returns all the relevant objects.
+    """
+    # Create a temporary directory for saving cache files and config
+    temp_dir = tmp_path_factory.mktemp("test_cache")
+
+    # Load model and set run configuration
+    model = AutoModelForCausalLM.from_pretrained("EleutherAI/pythia-70m")
+    run_cfg_gemma = RunConfig(
+        model="EleutherAI/pythia-70m",
+        sparse_model="EleutherAI/sae-pythia-70m-32k",
+        hookpoints=["layers.1"],
+    )
+    hookpoint_to_sae_encode = load_sparse_coders(model, run_cfg_gemma)
+
+    # Define cache config and initialize cache
+    cache_cfg = CacheConfig(batch_size=1, ctx_len=256, n_tokens=1000)
+    cache = LatentCache(model, hookpoint_to_sae_encode, batch_size=cache_cfg.batch_size)
+
+    # Generate mock tokens and run the cache
+    mock_tokens = torch.randint(0, 1000, (4, cache_cfg.ctx_len))
+    cache.run(cache_cfg.n_tokens, mock_tokens)
+
+    # Save splits to temporary directory (the layer key is "gpt_neox.layers.1")
+
+    cache.save_splits(n_splits=5, save_dir=temp_dir, save_tokens=True)
+
+    # Save the cache config
+
+    cache.save_config(temp_dir, cache_cfg, "EleutherAI/pythia-70m")
+
+    dict_to_return = {
+        "cache": cache,
+        "mock_tokens": mock_tokens,
+        "cache_cfg": cache_cfg,
+        "temp_dir": temp_dir,
+    }
+
+    yield dict_to_return
+    dict_to_return.clear()
+
+
+def test_latent_locations(cache_setup):
+    """
+    Test that the latent locations generated in memory have the expected
+    shape and values.
+    """
+    cache = cache_setup["cache"]
+    locations = cache.cache.latent_locations["gpt_neox.layers.1"]
+    max_values, _ = locations.max(axis=0)
+    # Expected values based on the cache run
+    assert max_values[0] == 2, "Expected first dimension max value to be 2"
+    assert max_values[1] == 255, "Expected token ids to go up to 255"
+    assert max_values[2] > 32760, "Expected latent dimension around 32768"
+
+
+def test_split_files_created(cache_setup):
+    """
+    Test that exactly 5 cache split files have been created.
+    """
+    save_dir = cache_setup["temp_dir"] / "gpt_neox.layers.1"
+    cache_files = [f for f in os.listdir(save_dir) if f.endswith(".safetensors")]
+    assert len(cache_files) == 5, "Expected 5 split files in the cache directory"
+
+
+def test_split_file_contents(cache_setup):
+    """
+    Test that one of the split files (loaded via safetensors) holds convincing data:
+    - latent locations and activations have the same number of entries,
+    - tokens were correctly stored and match the input tokens.
+    - latent max values are as expected.
+    """
+    save_dir = cache_setup["temp_dir"] / "gpt_neox.layers.1"
+    mock_tokens = cache_setup["mock_tokens"]
+    # Choose one file to verify
+    cache_files = os.listdir(save_dir)
+    file_path = Path(save_dir) / cache_files[0]
+    saved_cache = load_file(str(file_path))
+
+    locations = saved_cache["locations"]
+    activations = saved_cache["activations"]
+    tokens = saved_cache["tokens"]
+
+    assert len(locations) == len(
+        activations
+    ), "Mismatch between locations & activations entries"
+
+    np.testing.assert_array_equal(
+        tokens,
+        mock_tokens[:3, :].cpu().numpy(),
+        err_msg="Tokens saved do not match the input tokens",
+    )
+    max_values = locations.max(axis=0)
+    assert max_values[0] == 2, "Max batch index mismatch in saved file"
+    assert max_values[1] == 255, "Max token value mismatch in saved file"
+    assert max_values[2] > 6520, "Latent dimension mismatch in saved file"
+
+
+def test_config_file(cache_setup):
+    """
+    Test that the saved configuration file contains the correct parameters.
+    """
+    config_path = cache_setup["temp_dir"] / "gpt_neox.layers.1" / "config.json"
+    with open(config_path, "r") as f:
+        config = json.load(f)
+    cache_cfg = cache_setup["cache_cfg"]
+
+    assert config["batch_size"] == cache_cfg.batch_size, "Config batch_size mismatch"
+    assert config["ctx_len"] == cache_cfg.ctx_len, "Config ctx_len mismatch"
+    assert config["n_tokens"] == cache_cfg.n_tokens, "Config n_tokens mismatch"

--- a/delphi/tests/test_latents/test_cache.py
+++ b/delphi/tests/test_latents/test_cache.py
@@ -15,9 +15,9 @@ def test_latent_locations(cache_setup):
     locations = cache.cache.latent_locations["gpt_neox.layers.1"]
     max_values, _ = locations.max(axis=0)
     # Expected values based on the cache run
-    assert max_values[0] == 2, "Expected first dimension max value to be 2"
-    assert max_values[1] == 255, "Expected token ids to go up to 255"
-    assert max_values[2] > 32760, "Expected latent dimension around 32768"
+    assert max_values[0] == 5, "Expected first dimension max value to be 5"
+    assert max_values[1] == 15, "Expected token ids to go up to 15"
+    assert max_values[2] > 32700, "Expected latent dimension around 32768"
 
 
 def test_split_files_created(cache_setup):
@@ -37,7 +37,7 @@ def test_split_file_contents(cache_setup):
     - latent max values are as expected.
     """
     save_dir = cache_setup["temp_dir"] / "gpt_neox.layers.1"
-    mock_tokens = cache_setup["mock_tokens"]
+    tokens = cache_setup["tokens"]
     # Choose one file to verify
     cache_files = os.listdir(save_dir)
     file_path = Path(save_dir) / cache_files[0]
@@ -53,13 +53,13 @@ def test_split_file_contents(cache_setup):
 
     np.testing.assert_array_equal(
         tokens,
-        mock_tokens[:3, :].cpu().numpy(),
+        tokens[:12, :],
         err_msg="Tokens saved do not match the input tokens",
     )
     max_values = locations.max(axis=0)
-    assert max_values[0] == 2, "Max batch index mismatch in saved file"
-    assert max_values[1] == 255, "Max token value mismatch in saved file"
-    assert max_values[2] > 6520, "Latent dimension mismatch in saved file"
+    assert max_values[0] == 5, "Max batch index mismatch in saved file"
+    assert max_values[1] == 15, "Max token value mismatch in saved file"
+    assert max_values[2] > 6500, "Latent dimension mismatch in saved file"
 
 
 def test_config_file(cache_setup):

--- a/delphi/tests/test_latents/test_cache.py
+++ b/delphi/tests/test_latents/test_cache.py
@@ -1,12 +1,13 @@
 import json
 import os
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 from safetensors.numpy import load_file
 
 
-def test_latent_locations(cache_setup):
+def test_latent_locations(cache_setup: dict[str, Any]):
     """
     Test that the latent locations generated in memory have the expected
     shape and values.
@@ -20,7 +21,7 @@ def test_latent_locations(cache_setup):
     assert max_values[2] > 32700, "Expected latent dimension around 32768"
 
 
-def test_split_files_created(cache_setup):
+def test_split_files_created(cache_setup: dict[str, Any]):
     """
     Test that exactly 5 cache split files have been created.
     """
@@ -29,7 +30,7 @@ def test_split_files_created(cache_setup):
     assert len(cache_files) == 5, "Expected 5 split files in the cache directory"
 
 
-def test_split_file_contents(cache_setup):
+def test_split_file_contents(cache_setup: dict[str, Any]):
     """
     Test that one of the split files (loaded via safetensors) holds convincing data:
     - latent locations and activations have the same number of entries,
@@ -62,7 +63,7 @@ def test_split_file_contents(cache_setup):
     assert max_values[2] > 6500, "Latent dimension mismatch in saved file"
 
 
-def test_config_file(cache_setup):
+def test_config_file(cache_setup: dict[str, Any]):
     """
     Test that the saved configuration file contains the correct parameters.
     """

--- a/delphi/tests/test_latents/test_cache.py
+++ b/delphi/tests/test_latents/test_cache.py
@@ -4,59 +4,8 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import torch
+
 from safetensors.numpy import load_file
-from transformers import AutoModelForCausalLM
-
-from delphi.config import CacheConfig, RunConfig
-from delphi.latents import LatentCache
-from delphi.sparse_coders import load_sparse_coders
-
-
-@pytest.fixture(scope="module")
-def cache_setup(tmp_path_factory):
-    """
-    This fixture creates a temporary directory, loads the model,
-    initializes the cache, runs the cache once, saves the cache splits
-    and configuration, and returns all the relevant objects.
-    """
-    # Create a temporary directory for saving cache files and config
-    temp_dir = tmp_path_factory.mktemp("test_cache")
-
-    # Load model and set run configuration
-    model = AutoModelForCausalLM.from_pretrained("EleutherAI/pythia-70m")
-    run_cfg_gemma = RunConfig(
-        model="EleutherAI/pythia-70m",
-        sparse_model="EleutherAI/sae-pythia-70m-32k",
-        hookpoints=["layers.1"],
-    )
-    hookpoint_to_sae_encode = load_sparse_coders(model, run_cfg_gemma)
-
-    # Define cache config and initialize cache
-    cache_cfg = CacheConfig(batch_size=1, ctx_len=256, n_tokens=1000)
-    cache = LatentCache(model, hookpoint_to_sae_encode, batch_size=cache_cfg.batch_size)
-
-    # Generate mock tokens and run the cache
-    mock_tokens = torch.randint(0, 1000, (4, cache_cfg.ctx_len))
-    cache.run(cache_cfg.n_tokens, mock_tokens)
-
-    # Save splits to temporary directory (the layer key is "gpt_neox.layers.1")
-
-    cache.save_splits(n_splits=5, save_dir=temp_dir, save_tokens=True)
-
-    # Save the cache config
-
-    cache.save_config(temp_dir, cache_cfg, "EleutherAI/pythia-70m")
-
-    dict_to_return = {
-        "cache": cache,
-        "mock_tokens": mock_tokens,
-        "cache_cfg": cache_cfg,
-        "temp_dir": temp_dir,
-    }
-
-    yield dict_to_return
-    dict_to_return.clear()
 
 
 def test_latent_locations(cache_setup):

--- a/delphi/tests/test_latents/test_cache.py
+++ b/delphi/tests/test_latents/test_cache.py
@@ -3,8 +3,6 @@ import os
 from pathlib import Path
 
 import numpy as np
-import pytest
-
 from safetensors.numpy import load_file
 
 


### PR DESCRIPTION
This builts on top of of "cleaning_up_autoencoders".
- adds tests to caching as well
- removing the need to set the width when caching and loading latents. 
- removes Loader, now iterates using dataset

Still missing latent dataset tests, but we could maybe merge it directly and then I would work on that?
