### PR TITLE
Update to Tokenizer in loader.py

### DIFF
--- a/delphi/latents/loader.py
+++ b/delphi/latents/loader.py
@@ -9,7 +9,7 @@ import torch
 from safetensors.numpy import load_file
 from torchtyping import TensorType
 from tqdm import tqdm
-from transformers import AutoModel
+from transformers import AutoTokenizer
 
 from delphi.utils import (
     load_tokenized_data,
@@ -149,10 +149,7 @@ class LatentDataset:
         with open(cache_config_dir, "r") as f:
             cache_config = json.load(f)
         if tokenizer is None:
-            temp_model = AutoModel.from_pretrained(
-                cache_config["model_name"], device_map="cpu"
-            )
-            self.tokenizer = temp_model.tokenizer
+            self.tokenizer = AutoTokenizer.from_pretrained(cache_config["model_name"])
         else:
             self.tokenizer = tokenizer
         self.cache_config = cache_config


### PR DESCRIPTION
Load just the tokenizer instead of loading the whole model and accessing the tokenizer from it.

Why?
* Some models have no such attribute. (Or at least this is not compatible with all versions of Transformers Library.)
* For big models, this can be very costly!

Am I missing something?