### PR TITLE
Unified run_cfg, better named subconfigs

### DIFF
--- a/delphi/latents/samplers.py
+++ b/delphi/latents/samplers.py
@@ -1,7 +1,7 @@
 import random
 from typing import Literal
 
-from ..config import ExperimentConfig
+from ..config import SamplerConfig
 from ..logger import logger
 from .latents import ActivatingExample, LatentRecord
 
@@ -95,7 +95,7 @@ def test(
 
 def sampler(
     record: LatentRecord,
-    cfg: ExperimentConfig,
+    cfg: SamplerConfig,
 ):
     examples = record.examples
     max_activation = record.max_activation

--- a/delphi/tests/conftest.py
+++ b/delphi/tests/conftest.py
@@ -11,7 +11,7 @@ from transformers import (
     PreTrainedTokenizerFast,
 )
 
-from delphi.config import CacheConfig, RunConfig, ConstructorConfig, SamplerConfig
+from delphi.config import CacheConfig, ConstructorConfig, RunConfig, SamplerConfig
 from delphi.latents import LatentCache
 from delphi.sparse_coders import load_hooks_sparse_coders
 
@@ -68,7 +68,7 @@ def cache_setup(tmp_path_factory, mock_dataset: torch.Tensor, model: PreTrainedM
 
     # Load model and set run configuration
     cache_cfg = CacheConfig(batch_size=1, cache_ctx_len=16, n_tokens=100)
-    
+
     run_cfg_gemma = RunConfig(
         constructor_cfg=ConstructorConfig(),
         sampler_cfg=SamplerConfig(),

--- a/delphi/tests/conftest.py
+++ b/delphi/tests/conftest.py
@@ -11,7 +11,7 @@ from transformers import (
     PreTrainedTokenizerFast,
 )
 
-from delphi.config import CacheConfig, RunConfig
+from delphi.config import CacheConfig, RunConfig, ConstructorConfig, SamplerConfig
 from delphi.latents import LatentCache
 from delphi.sparse_coders import load_hooks_sparse_coders
 
@@ -67,7 +67,12 @@ def cache_setup(tmp_path_factory, mock_dataset: torch.Tensor, model: PreTrainedM
     temp_dir = tmp_path_factory.mktemp("test_cache")
 
     # Load model and set run configuration
+    cache_cfg = CacheConfig(batch_size=1, cache_ctx_len=16, n_tokens=100)
+    
     run_cfg_gemma = RunConfig(
+        constructor_cfg=ConstructorConfig(),
+        sampler_cfg=SamplerConfig(),
+        cache_cfg=cache_cfg,
         model="EleutherAI/pythia-160m",
         sparse_model="EleutherAI/sae-pythia-160m-32k",
         hookpoints=["layers.1"],
@@ -75,7 +80,6 @@ def cache_setup(tmp_path_factory, mock_dataset: torch.Tensor, model: PreTrainedM
     hookpoint_to_sparse_encode = load_hooks_sparse_coders(model, run_cfg_gemma)
     print(hookpoint_to_sparse_encode)
     # Define cache config and initialize cache
-    cache_cfg = CacheConfig(batch_size=1, ctx_len=16, n_tokens=100)
     cache = LatentCache(
         model, hookpoint_to_sparse_encode, batch_size=cache_cfg.batch_size
     )

--- a/delphi/tests/test_latents/test_cache.py
+++ b/delphi/tests/test_latents/test_cache.py
@@ -73,5 +73,5 @@ def test_config_file(cache_setup: dict[str, Any]):
     cache_cfg = cache_setup["cache_cfg"]
 
     assert config["batch_size"] == cache_cfg.batch_size, "Config batch_size mismatch"
-    assert config["ctx_len"] == cache_cfg.ctx_len, "Config ctx_len mismatch"
+    assert config["cache_ctx_len"] == cache_cfg.cache_ctx_len, "Cache_ctx_len mismatch"
     assert config["n_tokens"] == cache_cfg.n_tokens, "Config n_tokens mismatch"


### PR DESCRIPTION
Renamed configs to names that made sense, reformulated a bit where they were used (behaviour is the same) and unified them in run_config, so now we don't need to pass around 4 different configs. Everything works the same