### PR TITLE
Adding the ability to cache transcoders

### DIFF
--- a/delphi/__main__.py
+++ b/delphi/__main__.py
@@ -222,6 +222,7 @@ def populate_cache(
     hookpoint_to_sparse_encode: dict[str, Callable],
     latents_path: Path,
     tokenizer: PreTrainedTokenizer | PreTrainedTokenizerFast,
+    transcode: bool,
 ):
     """
     Populates an on-disk cache in `latents_path` with SAE latent activations.
@@ -254,6 +255,7 @@ def populate_cache(
         model,
         hookpoint_to_sparse_encode,
         batch_size=cache_cfg.batch_size,
+        transcode=transcode,
     )
     cache.run(cache_cfg.n_tokens, tokens)
 
@@ -329,6 +331,7 @@ async def run(
             nrh,
             latents_path,
             tokenizer,
+            run_cfg.transcode,
         )
 
     del model, hookpoint_to_sparse_encode

--- a/delphi/__main__.py
+++ b/delphi/__main__.py
@@ -49,9 +49,13 @@ def load_artifacts(run_cfg: RunConfig):
         token=run_cfg.hf_token,
     )
 
-    hookpoint_to_sparse_encode = load_hooks_sparse_coders(model, run_cfg, compile=True)
+    hookpoint_to_sparse_encode, transcode = load_hooks_sparse_coders(
+        model,
+        run_cfg,
+        compile=True,
+    )
 
-    return run_cfg.hookpoints, hookpoint_to_sparse_encode, model
+    return run_cfg.hookpoints, hookpoint_to_sparse_encode, model, transcode
 
 
 def create_neighbours(
@@ -318,7 +322,7 @@ async def run(
 
     latent_range = torch.arange(run_cfg.max_latents) if run_cfg.max_latents else None
 
-    hookpoints, hookpoint_to_sparse_encode, model = load_artifacts(run_cfg)
+    hookpoints, hookpoint_to_sparse_encode, model, transcode = load_artifacts(run_cfg)
     tokenizer = AutoTokenizer.from_pretrained(run_cfg.model, token=run_cfg.hf_token)
 
     nrh = non_redundant_hookpoints(
@@ -331,7 +335,7 @@ async def run(
             nrh,
             latents_path,
             tokenizer,
-            run_cfg.transcode,
+            transcode,
         )
 
     del model, hookpoint_to_sparse_encode

--- a/delphi/config.py
+++ b/delphi/config.py
@@ -106,9 +106,6 @@ class RunConfig(Serializable):
     hookpoints: list[str] = list_field()
     """list of model hookpoints to attach sparse models to."""
 
-    transcode: bool = False
-    """Whether to transcode the activations."""
-
     explainer_model: str = field(
         default="hugging-quants/Meta-Llama-3.1-70B-Instruct-AWQ-INT4",
     )

--- a/delphi/config.py
+++ b/delphi/config.py
@@ -106,6 +106,9 @@ class RunConfig(Serializable):
     hookpoints: list[str] = list_field()
     """list of model hookpoints to attach sparse models to."""
 
+    transcode: bool = False
+    """Whether to transcode the activations."""
+
     explainer_model: str = field(
         default="hugging-quants/Meta-Llama-3.1-70B-Instruct-AWQ-INT4",
     )

--- a/delphi/latents/cache.py
+++ b/delphi/latents/cache.py
@@ -180,6 +180,7 @@ class LatentCache:
         model: PreTrainedModel,
         hookpoint_to_sparse_encode: dict[str, Callable],
         batch_size: int,
+        transcode: bool = False,
         filters: dict[str, Float[Tensor, "indices"]] | None = None,
     ):
         """
@@ -193,7 +194,7 @@ class LatentCache:
         """
         self.model = model
         self.hookpoint_to_sparse_encode = hookpoint_to_sparse_encode
-
+        self.transcode = transcode
         self.batch_size = batch_size
         self.width = None
         self.cache = Cache(filters, batch_size=batch_size)
@@ -258,7 +259,9 @@ class LatentCache:
 
                 with torch.no_grad():
                     with collect_activations(
-                        self.model, list(self.hookpoint_to_sparse_encode.keys())
+                        self.model,
+                        list(self.hookpoint_to_sparse_encode.keys()),
+                        self.transcode,
                     ) as activations:
                         self.model(batch.to(self.model.device))
 

--- a/delphi/latents/collect_activations.py
+++ b/delphi/latents/collect_activations.py
@@ -6,7 +6,9 @@ from transformers import PreTrainedModel
 
 
 @contextmanager
-def collect_activations(model: PreTrainedModel, hookpoints: list[str]):
+def collect_activations(
+    model: PreTrainedModel, hookpoints: list[str], transcode: bool = False
+):
     """
     Context manager that temporarily hooks models and collects their activations.
     An activation tensor is produced for each batch processed and stored in a list
@@ -22,19 +24,25 @@ def collect_activations(model: PreTrainedModel, hookpoints: list[str]):
     activations = {}
     handles = []
 
-    def create_hook(hookpoint: str):
+    def create_hook(hookpoint: str, transcode: bool = False):
         def hook_fn(module: nn.Module, input: Any, output: Tensor) -> Tensor | None:
             # If output is a tuple (like in some transformer layers), take first element
-            if isinstance(output, tuple):
-                activations[hookpoint] = output[0]
+            if transcode:
+                if isinstance(input, tuple):
+                    activations[hookpoint] = input[0]
+                else:
+                    activations[hookpoint] = input.transpose(1, 2)
             else:
-                activations[hookpoint] = output
+                if isinstance(output, tuple):
+                    activations[hookpoint] = output[0]
+                else:
+                    activations[hookpoint] = output
 
         return hook_fn
 
     for name, module in model.named_modules():
         if name in hookpoints:
-            handle = module.register_forward_hook(create_hook(name))
+            handle = module.register_forward_hook(create_hook(name, transcode))
             handles.append(handle)
 
     try:

--- a/delphi/latents/collect_activations.py
+++ b/delphi/latents/collect_activations.py
@@ -31,7 +31,7 @@ def collect_activations(
                 if isinstance(input, tuple):
                     activations[hookpoint] = input[0]
                 else:
-                    activations[hookpoint] = input.transpose(1, 2)
+                    activations[hookpoint] = input
             else:
                 if isinstance(output, tuple):
                     activations[hookpoint] = output[0]

--- a/delphi/sparse_coders/load_sparsify.py
+++ b/delphi/sparse_coders/load_sparsify.py
@@ -94,7 +94,7 @@ def load_sparsify_hooks(
     hookpoints: list[str],
     device: str | torch.device | None = None,
     compile: bool = False,
-) -> dict[str, Callable]:
+) -> tuple[dict[str, Callable], bool]:
     """
     Load the encode functions for sparsify sparse coders on specified hookpoints.
 
@@ -118,6 +118,7 @@ def load_sparsify_hooks(
         compile,
     )
     hookpoint_to_sparse_encode = {}
+    transcode = False
     for hookpoint, sparse_model in sparse_model_dict.items():
         print(f"Resolving path for hookpoint: {hookpoint}")
         path_segments = resolve_path(model, hookpoint.split("."))
@@ -127,5 +128,10 @@ def load_sparsify_hooks(
         hookpoint_to_sparse_encode[".".join(path_segments)] = partial(
             sae_dense_latents, sae=sparse_model
         )
-
-    return hookpoint_to_sparse_encode
+        if hasattr(sparse_model.cfg, "transcode"):
+            if sparse_model.cfg.transcode:
+                transcode = True
+        if hasattr(sparse_model.cfg, "skip_connection"):
+            if sparse_model.cfg.skip_connection:
+                transcode = True
+    return hookpoint_to_sparse_encode, transcode

--- a/delphi/sparse_coders/load_sparsify.py
+++ b/delphi/sparse_coders/load_sparsify.py
@@ -128,6 +128,7 @@ def load_sparsify_hooks(
         hookpoint_to_sparse_encode[".".join(path_segments)] = partial(
             sae_dense_latents, sae=sparse_model
         )
+        # We only need to check if one of the sparse models is a transcoder
         if hasattr(sparse_model.cfg, "transcode"):
             if sparse_model.cfg.transcode:
                 transcode = True

--- a/delphi/sparse_coders/sparse_model.py
+++ b/delphi/sparse_coders/sparse_model.py
@@ -7,14 +7,14 @@ from transformers import PreTrainedModel
 from delphi.config import RunConfig
 
 from .custom.gemmascope import load_gemma_autoencoders
-from .load_sparsify import Sae, load_sparsify_hooks, load_sparsify_sparse_coders
+from .load_sparsify import load_sparsify_hooks, load_sparsify_sparse_coders
 
 
 def load_hooks_sparse_coders(
     model: PreTrainedModel,
     run_cfg: RunConfig,
     compile: bool = False,
-) -> dict[str, Callable]:
+) -> tuple[dict[str, Callable], bool]:
     """
     Load sparse coders for specified hookpoints.
 
@@ -28,7 +28,7 @@ def load_hooks_sparse_coders(
 
     # Add SAE hooks to the model
     if "gemma" not in run_cfg.sparse_model:
-        hookpoint_to_sparse_encode = load_sparsify_hooks(
+        hookpoint_to_sparse_encode, transcode = load_sparsify_hooks(
             model,
             run_cfg.sparse_model,
             run_cfg.hookpoints,
@@ -63,17 +63,18 @@ def load_hooks_sparse_coders(
             dtype=model.dtype,
             device=model.device,
         )
+        transcode = False
     # throw an error if the dictionary is empty
     if not hookpoint_to_sparse_encode:
         raise ValueError("No sparse coders loaded")
-    return hookpoint_to_sparse_encode
+    return hookpoint_to_sparse_encode, transcode
 
 
 def load_sparse_coders(
     run_cfg: RunConfig,
     device: str | torch.device,
     compile: bool = False,
-) -> dict[str, nn.Module] | dict[str, Sae]:
+) -> dict[str, nn.Module]:
     """
     Load sparse coders for specified hookpoints.
 


### PR DESCRIPTION
I'm not sure if this is the most elegant option. I think I would prefer not to use a new keyword and just read it from the config when loading the sparse model, but that would mean making all the load functions slightly different. 