### PR TITLE
add faiss index backed contrastive explainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,44 @@ dataset = LatentDataset(
 )
 ```
 
+### FAISS Index for Hard Negatives
+
+When constructing features for explanation, you can use FAISS (semantic similarity search) to create hard negative examples. Hard negatives are non-activating examples that are semantically similar to activating examples. This approach:
+
+1. Creates embeddings for both activating and non-activating examples using the specified embedding model
+2. Builds a FAISS index for efficient similarity search
+3. Finds non-activating examples that are semantically similar to activating examples
+4. Optionally caches embeddings to speed up future runs
+
+To use FAISS for hard negatives, set the `non_activating_source` parameter to "FAISS" in your `ConstructorConfig`:
+
+```python
+from delphi.config import ConstructorConfig
+
+constructor_cfg = ConstructorConfig(
+    non_activating_source="FAISS",
+    faiss_embedding_model="sentence-transformers/all-MiniLM-L6-v2",
+    faiss_embedding_cache_enabled=True,
+    faiss_embedding_cache_dir=".embedding_cache"
+)
+```
+
+### Contrastive Explainer
+
+The `ContrastiveExplainer` adds both positive (activating) and negative (non-activating) examples to a single explainer prompt so the explainer model is less likely to label features that are not exclusive to the feature activations (ie we are more likely to provide non activating tokens which are semantically similar). This explainer is automatically used when the `non_activating_source` is set to "FAISS".
+
+```python
+from delphi.explainers import ContrastiveExplainer
+
+explainer = ContrastiveExplainer(
+    client,
+    threshold=0.3,
+    max_examples=15,
+    max_non_activating=5,
+    verbose=True
+)
+```
+
 ## Generating Explanations
 
 We currently support using OpenRouter's OpenAI compatible API or running locally with VLLM. Define the client you want to use, then create an explainer from the `.explainers` module.

--- a/delphi/config.py
+++ b/delphi/config.py
@@ -26,6 +26,15 @@ class SamplerConfig(Serializable):
 
 @dataclass
 class ConstructorConfig(Serializable):
+    faiss_embedding_model: str = "sentence-transformers/all-MiniLM-L6-v2"
+    """Embedding model to use for FAISS index."""
+
+    faiss_embedding_cache_dir: str = ".embedding_cache"
+    """Directory to store cached embeddings for FAISS similarity search."""
+
+    faiss_embedding_cache_enabled: bool = True
+    """Whether to cache embeddings for FAISS similarity search."""
+
     example_ctx_len: int = 32
     """Length of each sampled example sequence. Longer sequences
     reduce detection scoring performance in weak models.
@@ -42,11 +51,12 @@ class ConstructorConfig(Serializable):
     n_non_activating: int = 50
     """Number of non-activating examples to be constructed."""
 
-    non_activating_source: Literal["random", "neighbours"] = "random"
+    non_activating_source: Literal["random", "neighbours", "FAISS"] = "random"
     """Source of non-activating examples. Random uses non-activating contexts
     sampled from any non activating window. Neighbours uses actvating contexts
-    from pre-computed latent neighbours. They are still non-activating but
-    have a higher chance of being similar to the activating examples."""
+    from pre-computed latent neighbours. FAISS uses semantic similarity search
+    to find hard negatives that are semantically similar to activating examples
+    but don't activate the latent."""
 
     neighbours_type: Literal[
         "co-occurrence", "decoder_similarity", "encoder_similarity"

--- a/delphi/explainers/__init__.py
+++ b/delphi/explainers/__init__.py
@@ -1,3 +1,4 @@
+from .contrastive_explainer import ContrastiveExplainer
 from .default.default import DefaultExplainer
 from .explainer import Explainer, explanation_loader, random_explanation_loader
 from .single_token_explainer import SingleTokenExplainer
@@ -8,4 +9,5 @@ __all__ = [
     "SingleTokenExplainer",
     "explanation_loader",
     "random_explanation_loader",
+    "ContrastiveExplainer",
 ]

--- a/delphi/explainers/contrastive_explainer.py
+++ b/delphi/explainers/contrastive_explainer.py
@@ -1,0 +1,143 @@
+import asyncio
+from dataclasses import dataclass
+
+import torch
+
+from delphi.explainers.default.prompts import SYSTEM_CONTRASTIVE
+from delphi.explainers.explainer import Explainer, ExplainerResult
+from delphi.latents.latents import ActivatingExample, LatentRecord, NonActivatingExample
+
+
+@dataclass
+class ContrastiveExplainer(Explainer):
+    activations: bool = True
+    """Whether to show activations to the explainer."""
+    max_examples: int = 15
+    """Maximum number of activating examples to use."""
+    max_non_activating: int = 5
+    """Maximum number of non-activating examples to use."""
+
+    async def __call__(self, record: LatentRecord) -> ExplainerResult:
+        """
+        Override the base __call__ method to use both train and not_active examples.
+
+        Args:
+            record: The latent record containing both activating and
+                non-activating examples.
+
+        Returns:
+            ExplainerResult: The explainer result containing the explanation.
+        """
+        # Sample from both activating and non-activating examples
+        activating_examples = record.train[: self.max_examples]
+
+        non_activating_examples = []
+        if len(record.not_active) > 0:
+            non_activating_examples = record.not_active[: self.max_non_activating]
+
+            # Ensure non-activating examples have normalized activations for consistency
+            for example in non_activating_examples:
+                if example.normalized_activations is None:
+                    # Use zeros for non-activating examples
+                    example.normalized_activations = torch.zeros_like(
+                        example.activations
+                    )
+
+        # Combine examples for the prompt
+        combined_examples = activating_examples + non_activating_examples
+
+        # Build the prompt with both types of examples
+        messages = self._build_prompt(combined_examples)
+        print("message", messages[-1]["content"])
+
+        # Generate the explanation
+        response = await self.client.generate(
+            messages, temperature=self.temperature, **self.generation_kwargs
+        )
+
+        try:
+            explanation = self.parse_explanation(response.text)
+            if self.verbose:
+                from ..logger import logger
+
+                logger.info(f"Explanation: {explanation}")
+                logger.info(f"Messages: {messages[-1]['content']}")
+                logger.info(f"Response: {response}")
+
+            return ExplainerResult(record=record, explanation=explanation)
+        except Exception as e:
+            from ..logger import logger
+
+            logger.error(f"Explanation parsing failed: {e}")
+            return ExplainerResult(
+                record=record, explanation="Explanation could not be parsed."
+            )
+
+    def _build_prompt(
+        self, examples: list[ActivatingExample | NonActivatingExample]
+    ) -> list[dict]:
+        """
+        Build a prompt with both activating and non-activating examples clearly labeled.
+
+        Args:
+            examples: List containing both activating and non-activating examples.
+
+        Returns:
+            A list of message dictionaries for the prompt.
+        """
+        highlighted_examples = []
+
+        # First, separate activating and non-activating examples
+        activating_examples = [
+            ex for ex in examples if isinstance(ex, ActivatingExample)
+        ]
+        non_activating_examples = [
+            ex for ex in examples if not isinstance(ex, ActivatingExample)
+        ]
+
+        # Process activating examples
+        if activating_examples:
+            highlighted_examples.append("ACTIVATING EXAMPLES:")
+            for i, example in enumerate(activating_examples, 1):
+                str_toks = example.str_tokens
+                activations = example.activations.tolist()
+                ex = self._highlight(str_toks, activations).strip().replace("\n", "")
+                highlighted_examples.append(f"Example {i}:  {ex}")
+
+                if self.activations and example.normalized_activations is not None:
+                    normalized_activations = example.normalized_activations.tolist()
+                    highlighted_examples.append(
+                        self._join_activations(
+                            str_toks, activations, normalized_activations
+                        )
+                    )
+
+        # Process non-activating examples
+        if non_activating_examples:
+            highlighted_examples.append("\nNON-ACTIVATING EXAMPLES:")
+            for i, example in enumerate(non_activating_examples, 1):
+                str_toks = example.str_tokens
+                activations = example.activations.tolist()
+                # Note: For non-activating examples, the _highlight method won't
+                # highlight anything since activation values will be below threshold
+                ex = self._highlight(str_toks, activations).strip().replace("\n", "")
+                highlighted_examples.append(f"Example {i}:  {ex}")
+
+        # Join all sections into a single string
+        highlighted_examples_str = "\n".join(highlighted_examples)
+
+        # Create messages array with the system prompt
+        return [
+            {
+                "role": "system",
+                "content": SYSTEM_CONTRASTIVE,
+            },
+            {
+                "role": "user",
+                "content": highlighted_examples_str,
+            },
+        ]
+
+    def call_sync(self, record):
+        """Synchronous wrapper for the asynchronous __call__ method."""
+        return asyncio.run(self.__call__(record))

--- a/delphi/explainers/contrastive_explainer.py
+++ b/delphi/explainers/contrastive_explainer.py
@@ -48,8 +48,6 @@ class ContrastiveExplainer(Explainer):
 
         # Build the prompt with both types of examples
         messages = self._build_prompt(combined_examples)
-        print("message", messages[-1]["content"])
-
         # Generate the explanation
         response = await self.client.generate(
             messages, temperature=self.temperature, **self.generation_kwargs
@@ -73,7 +71,7 @@ class ContrastiveExplainer(Explainer):
                 record=record, explanation="Explanation could not be parsed."
             )
 
-    def _build_prompt(
+    def _build_prompt(  # type: ignore
         self, examples: list[ActivatingExample | NonActivatingExample]
     ) -> list[dict]:
         """

--- a/delphi/explainers/default/prompts.py
+++ b/delphi/explainers/default/prompts.py
@@ -37,6 +37,19 @@ You will be given a list of text examples on which special words are selected an
 {prompt}
 """
 
+SYSTEM_CONTRASTIVE = """You are a meticulous AI researcher conducting an important investigation into patterns found in language. Your task is to analyze text and provide an explanation that thoroughly encapsulates possible patterns found in it.
+Guidelines:
+
+You will be given a list of text examples on which special words are selected and between delimiters like <<this>>. If a sequence of consecutive tokens all are important, the entire sequence of tokens will be contained between delimiters <<just like this>>. How important each token is for the behavior is listed after each example in parentheses.
+
+- Try to produce a concise final description. Simply describe the text latents that are common in the examples, and what patterns you found.
+- Counterexamples where no special words are present are also provided to help you understand the patterns' edge cases.
+- If the examples are uninformative, you don't need to mention them. Don't focus on giving examples of important tokens, but try to summarize the patterns found in the examples.
+- Do not mention the marker tokens (<< >>) in your explanation.
+- Do not make lists of possible explanations. Keep your explanations short and concise.
+- The last line of your response must be the formatted explanation, using [EXPLANATION]:
+"""
+
 
 COT = """
 To better find the explanation for the language patterns go through the following stages:
@@ -228,3 +241,7 @@ def system(cot=False):
 
 def system_single_token():
     return [{"role": "system", "content": SYSTEM_SINGLE_TOKEN}]
+
+
+def system_contrastive():
+    return [{"role": "system", "content": SYSTEM_CONTRASTIVE}]

--- a/delphi/latents/constructors.py
+++ b/delphi/latents/constructors.py
@@ -1,7 +1,14 @@
+import hashlib
+import os
+from collections import defaultdict
+from pathlib import Path
 from typing import Optional
 
+import faiss
+import numpy as np
 import torch
 from jaxtyping import Float
+from sentence_transformers import SentenceTransformer
 from torch import Tensor
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 
@@ -12,6 +19,16 @@ from .latents import (
     LatentRecord,
     NonActivatingExample,
 )
+
+model = defaultdict(lambda: None)
+
+
+def get_model(name: str, device: str = "cuda") -> SentenceTransformer:
+    global model
+    if model[(name, device)] is None:
+        print(f"Loading model {name} on device {device}")
+        model[(name, device)] = SentenceTransformer(name, device=device)
+    return model[(name, device)]
 
 
 def prepare_non_activating_examples(
@@ -189,11 +206,228 @@ def constructor(
             seed=seed,
             tokenizer=tokenizer,
         )
-    else:
-        raise ValueError(f"Invalid non-activating source: {source_non_activating}")
-
+    elif source_non_activating == "FAISS":
+        non_activating_examples = faiss_non_activation_windows(
+            available_indices=non_active_indices,
+            record=record,
+            tokens=tokens,
+            ctx_len=example_ctx_len,
+            tokenizer=tokenizer,
+            n_not_active=n_not_active,
+            embedding_model=constructor_cfg.faiss_embedding_model,
+            seed=seed,
+            cache_enabled=constructor_cfg.faiss_embedding_cache_enabled,
+            cache_dir=constructor_cfg.faiss_embedding_cache_dir,
+        )
     record.not_active = non_activating_examples
     return record
+
+
+def create_token_key(tokens_tensor, ctx_len):
+    """
+    Create a file key based on token tensors without detokenization.
+
+    Args:
+        tokens_tensor: Tensor of tokens
+        ctx_len: Context length
+
+    Returns:
+        A string key
+    """
+    h = hashlib.md5()
+    total_tokens = 0
+
+    # Process a sample of elements (first, middle, last)
+    num_samples = len(tokens_tensor)
+    indices_to_hash = (
+        [0, num_samples // 2, -1] if num_samples >= 3 else range(num_samples)
+    )
+
+    for idx in indices_to_hash:
+        if 0 <= idx < num_samples or (idx == -1 and num_samples > 0):
+            # Convert tensor to bytes and hash it
+            token_bytes = tokens_tensor[idx].cpu().numpy().tobytes()
+            h.update(token_bytes)
+            total_tokens += len(tokens_tensor[idx])
+
+    # Add collection shape to make collisions less likely
+    shape_str = f"{tokens_tensor.shape}"
+    h.update(shape_str.encode())
+
+    return f"{h.hexdigest()[:12]}_items{num_samples}_{ctx_len}"
+
+
+def faiss_non_activation_windows(
+    available_indices: Float[Tensor, "windows"],
+    record: LatentRecord,
+    tokens: Float[Tensor, "batch seq"],
+    ctx_len: int,
+    tokenizer: PreTrainedTokenizer | PreTrainedTokenizerFast,
+    n_not_active: int,
+    embedding_model: str = "sentence-transformers/all-MiniLM-L6-v2",
+    seed: int = 42,
+    cache_enabled: bool = True,
+    cache_dir: str = ".embedding_cache",
+) -> list[NonActivatingExample]:
+    """
+    Generate hard negative examples using FAISS similarity search based
+    on text embeddings.
+
+    This function builds a FAISS index over non-activating examples and
+    finds examples that are semantically similar to the activating examples
+    based on text embeddings.
+
+    Args:
+        available_indices: Indices of windows where the latent is not active
+        record: The latent record containing activating examples
+        tokens: The input tokens
+        ctx_len: The context length for examples
+        tokenizer: The tokenizer to decode tokens
+        n_not_active: Number of non-activating examples to generate
+        embedding_model: Model used for text embeddings
+        seed: Random seed
+        cache_enabled: Whether to cache embeddings
+        cache_dir: Directory to store cached embeddings
+
+    Returns:
+        A list of non-activating examples that are semantically similar to
+            activating examples
+    """
+    torch.manual_seed(seed)
+    if n_not_active == 0:
+        return []
+
+    # Check if we have enough non-activating examples
+    if available_indices.numel() < n_not_active:
+        print("Not enough non-activating examples available")
+        return []
+
+    # Reshape tokens to get context windows
+    reshaped_tokens = tokens.reshape(-1, ctx_len)
+
+    # Get non-activating token windows
+    non_activating_tokens = reshaped_tokens[available_indices]
+
+    # Define cache directory structure
+    cache_dir = Path(os.environ.get("DELPHI_CACHE_DIR", cache_dir))
+    embedding_model_name = embedding_model.split("/")[-1]
+    cache_path = cache_dir / embedding_model_name
+
+    # Get activating example texts
+    activating_texts = [
+        "".join(example.str_tokens)
+        for example in record.examples[: min(10, len(record.examples))]
+    ]
+
+    if not activating_texts:
+        print("No activating examples available")
+        return []
+
+    # Create unique cache keys for both activating and non-activating texts
+    # Use the hash of the concatenated texts to ensure uniqueness
+    non_activating_cache_key = create_token_key(non_activating_tokens, ctx_len)
+    activating_cache_key = create_token_key(
+        torch.stack(
+            [
+                example.tokens
+                for example in record.examples[: min(10, len(record.examples))]
+            ]
+        ),
+        ctx_len,
+    )
+
+    # Cache files for activating and non-activating embeddings
+    non_activating_cache_file = cache_path / f"{non_activating_cache_key}.faiss"
+    activating_cache_file = cache_path / f"{activating_cache_key}.npy"
+
+    # Try to load cached non-activating embeddings
+    index = None
+    if cache_enabled and non_activating_cache_file.exists():
+        try:
+            index = faiss.read_index(str(non_activating_cache_file), faiss.IO_FLAG_MMAP)
+            print(f"Loaded non-activating index from {non_activating_cache_file}")
+        except Exception as e:
+            print(f"Error loading cached embeddings: {e}")
+
+    if index is None:
+        print("Decoding non-activating tokens...")
+        non_activating_texts = [
+            "".join(tokenizer.batch_decode(tokens)) for tokens in non_activating_tokens
+        ]
+
+        print("Computing non-activating embeddings...")
+        non_activating_embeddings = get_model(embedding_model).encode(
+            non_activating_texts, show_progress_bar=False
+        )
+        dim = non_activating_embeddings.shape[1]
+        index = faiss.IndexFlatL2(dim)
+
+        index.add(non_activating_embeddings)
+        if cache_enabled:
+            os.makedirs(cache_path, exist_ok=True)
+            faiss.write_index(index, str(non_activating_cache_file))
+            print(f"Cached non-activating embeddings to {non_activating_cache_file}")
+
+    activating_embeddings = None
+    if cache_enabled and activating_cache_file.exists():
+        try:
+            activating_embeddings = np.load(activating_cache_file)
+            print(f"Loaded cached activating embeddings from {activating_cache_file}")
+        except Exception as e:
+            print(f"Error loading cached embeddings: {e}")
+    # Compute embeddings for activating examples if not cached
+    if activating_embeddings is None:
+        print("Computing activating embeddings...")
+        activating_embeddings = get_model(embedding_model).encode(
+            activating_texts, show_progress_bar=False
+        )
+        # Cache the embeddings
+        if cache_enabled:
+            os.makedirs(cache_path, exist_ok=True)
+            np.save(activating_cache_file, activating_embeddings)
+            print(f"Cached activating embeddings to {activating_cache_file}")
+
+    # Search for the nearest neighbors to each activating example
+    collected_indices = set()
+    hard_negative_indices = []
+
+    # For each activating example, find the closest non-activating examples
+    for embedding in activating_embeddings:
+        # Skip if we already have enough examples
+        if len(hard_negative_indices) >= n_not_active:
+            break
+
+        # Search for similar non-activating examples
+        distances, indices = index.search(embedding.reshape(1, -1), n_not_active)
+
+        # Add new indices that haven't been collected yet
+        for idx in indices[0]:
+            if (
+                idx not in collected_indices
+                and len(hard_negative_indices) < n_not_active
+            ):
+                hard_negative_indices.append(idx)
+                collected_indices.add(idx)
+
+    # If we don't have enough hard negatives, add some random ones
+    if len(hard_negative_indices) < n_not_active:
+        remaining = n_not_active - len(hard_negative_indices)
+        available_indices_set = (
+            set(range(len(non_activating_embeddings))) - collected_indices
+        )
+        if available_indices_set:
+            random_indices = torch.tensor(list(available_indices_set))[
+                torch.randperm(len(available_indices_set))[:remaining]
+            ]
+            hard_negative_indices.extend(random_indices.tolist())
+    # Get the token windows for the selected hard negatives
+    selected_tokens = non_activating_tokens[hard_negative_indices]
+    # Create non-activating examples
+    return prepare_non_activating_examples(
+        selected_tokens,
+        -1.0,  # Using -1.0 as the distance since these are not neighbour-based
+        tokenizer,
+    )
 
 
 def neighbour_non_activation_windows(

--- a/delphi/tests/e2e.py
+++ b/delphi/tests/e2e.py
@@ -32,6 +32,8 @@ async def test():
         example_ctx_len=32,
         n_non_activating=50,
         non_activating_source="random",
+        faiss_embedding_cache_enabled=True,
+        faiss_embedding_cache_dir=".embedding_cache",
     )
     run_cfg = RunConfig(
         name="test",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,15 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest"]
+dev = [
+    "pytest",
+    "pyright==1.1.378"
+]
 visualize = [
     "kaleido==0.2.1",
     "plotly>=5.0.0rc2",
-    "pandas"
+    "pandas",
+    "ipywidgets"
 ]
 
 [tool.pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "vllm",
     "aiofiles",
     "sentence_transformers",
-    "anyio>=4.8.0"
+    "anyio>=4.8.0",
+    "faiss-cpu"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
add contrastive explainer to include hard negatives from using faiss semantic index
faiss index is cached, so subsequent runs only incur <10% extra latency end to end compared to `random`