### PR TITLE
Clean up firing rate log path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,5 @@ cython_debug/
 results/
 .vscode/
 statistics/
+.embedding_cache/
+wandb/

--- a/delphi/__main__.py
+++ b/delphi/__main__.py
@@ -277,9 +277,7 @@ def populate_cache(
     )
     cache.run(cache_cfg.n_tokens, tokens)
 
-    # Save firing counts to the run-specific log directory
     if run_cfg.verbose:
-        cache.save_firing_counts()
         cache.generate_statistics_cache()
 
     cache.save_splits(

--- a/delphi/config.py
+++ b/delphi/config.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from multiprocessing import cpu_count
 from typing import Literal
 
+import torch
 from simple_parsing import Serializable, field, list_field
 
 
@@ -143,7 +144,7 @@ class RunConfig(Serializable):
     """Number of processes to use for preprocessing data"""
 
     num_gpus: int = field(
-        default=1,
+        default=torch.cuda.device_count(),
     )
     """Number of GPUs to use for explanation and scoring."""
 
@@ -165,7 +166,8 @@ class RunConfig(Serializable):
     as well as increasing the scorer LLM task difficulty."""
 
     overwrite: list[Literal["cache", "neighbours", "scores"]] = list_field(
-        choices=["cache", "neighbours", "scores"]
+        choices=["cache", "neighbours", "scores"],
+        default=[],
     )
 
     """List of run stages to recompute. This is a debugging tool

--- a/delphi/latents/cache.py
+++ b/delphi/latents/cache.py
@@ -19,7 +19,7 @@ location_tensor_shape = Float[Tensor, "batch sequence num_latents"]
 token_tensor_shape = Float[Tensor, "batch sequence"]
 
 
-class Cache:
+class InMemoryCache:
     """
     The Cache class stores latent locations and activations for modules.
     It provides methods for adding, saving, and retrieving non-zero activations.
@@ -201,8 +201,9 @@ class LatentCache:
         self.transcode = transcode
         self.batch_size = batch_size
         self.width = None
-        self.cache = Cache(filters, batch_size=batch_size)
+        self.cache = InMemoryCache(filters, batch_size=batch_size)
         self.hookpoint_firing_counts: dict[str, Tensor] = {}
+
         self.log_path = log_path
         if filters is not None:
             self.filter_submodules(filters)
@@ -260,7 +261,6 @@ class LatentCache:
         total_tokens = 0
         total_batches = len(token_batches)
         tokens_per_batch = token_batches[0].numel()
-
         with tqdm(total=total_batches, desc="Caching latents") as pbar:
             for batch_number, batch in enumerate(token_batches):
                 total_tokens += tokens_per_batch
@@ -281,6 +281,7 @@ class LatentCache:
                             firing_counts = (sae_latents > 0).sum((0, 1))
                             if self.width is None:
                                 self.width = sae_latents.shape[2]
+
                             if hookpoint not in self.hookpoint_firing_counts:
                                 self.hookpoint_firing_counts[hookpoint] = (
                                     firing_counts.cpu()
@@ -296,6 +297,7 @@ class LatentCache:
 
         print(f"Total tokens processed: {total_tokens:,}")
         self.cache.save()
+        self.save_firing_counts()
 
     def save(self, save_dir: Path, save_tokens: bool = True):
         """
@@ -421,7 +423,6 @@ class LatentCache:
                 config_dict = cfg.to_dict()
                 config_dict["model_name"] = model_name
                 json.dump(config_dict, f, indent=4)
-        self.save_firing_counts()
 
     def save_firing_counts(self):
         """

--- a/delphi/log/result_analysis.py
+++ b/delphi/log/result_analysis.py
@@ -267,9 +267,8 @@ def plot_line(df: pd.DataFrame, visualize_path: Path):
 
 
 def log_results(scores_path: Path, visualize_path: Path, target_modules: list[str]):
-    hookpoint_firing_counts: dict[str, Tensor] = torch.load(
-        Path.cwd() / "results" / "log" / "hookpoint_firing_counts.pt", weights_only=True
-    )
+    log_path = scores_path.parent / "log" / "hookpoint_firing_counts.pt"
+    hookpoint_firing_counts: dict[str, Tensor] = torch.load(log_path, weights_only=True)
     df = build_scores_df(scores_path, target_modules, hookpoint_firing_counts)
 
     # Calculate the number of dead features for each module which will not be in the df

--- a/delphi/tests/e2e.py
+++ b/delphi/tests/e2e.py
@@ -57,9 +57,10 @@ async def test():
     print(f"Time taken: {end_time - start_time} seconds")
 
     # Performs better than random guessing
-    scores_path = Path("results") / run_cfg.name / "scores"
+    scores_path = Path.cwd() / "results" / run_cfg.name / "scores"
     hookpoint_firing_counts = torch.load(
-        Path.cwd() / "results" / "log" / "hookpoint_firing_counts.pt", weights_only=True
+        Path.cwd() / "results" / run_cfg.name / "log" / "hookpoint_firing_counts.pt",
+        weights_only=True,
     )
     df = build_scores_df(scores_path, run_cfg.hookpoints, hookpoint_firing_counts)
     for score_type in df["score_type"].unique():


### PR DESCRIPTION
- Clean up firing rate log path and save automatically in a sensible place
- Use all gpus by default
- rename cache to in memory cache to help me remember that it's different from the latent cache