### PR TITLE
Fix: sae input is collected instead of sae latent

### DIFF
--- a/delphi/latents/cache.py
+++ b/delphi/latents/cache.py
@@ -277,7 +277,7 @@ class LatentCache:
                         self.model(batch.to(self.model.device))
 
                         for hookpoint, latents in activations.items():
-                            sae_latents = self.hookpoint_to_sparse_encode[hookpoint](
+                            sae_latents = self.hookpoint_to_sparse_encode[hookpoint].encode(
                                 latents
                             )
                             self.cache.add(sae_latents, batch, batch_number, hookpoint)


### PR DESCRIPTION
The latent cache should store the sparse activations generated by the SAE encoder. However, the following line mistakenly stores the decoder’s output instead as it calls the forward function instead of encode function.

https://github.com/EleutherAI/delphi/blob/aff973dfe3645dedd530345b3f9ab04b8aa984ff/delphi/latents/cache.py#L280