### PR TITLE
fix bugs in _prepare_text and IntruderScorer prompt formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ results/
 statistics/
 .embedding_cache/
 wandb/
+uv.lock

--- a/delphi/pipeline.py
+++ b/delphi/pipeline.py
@@ -161,8 +161,9 @@ class Pipeline:
         async with semaphore:
             result = item
             for pipe in self.pipes:
-                if result is not None:
-                    result = await pipe(result)
-                else:
-                    pass
+                if result is None:
+                    break
+
+                result = await pipe(result)
+
         return result

--- a/delphi/pipeline.py
+++ b/delphi/pipeline.py
@@ -161,9 +161,8 @@ class Pipeline:
         async with semaphore:
             result = item
             for pipe in self.pipes:
-                if result is None:
-                    break
-
-                result = await pipe(result)
-
+                if result is not None:
+                    result = await pipe(result)
+                else:
+                    pass
         return result

--- a/delphi/scorers/classifier/intruder.py
+++ b/delphi/scorers/classifier/intruder.py
@@ -171,13 +171,13 @@ class IntruderScorer(Classifier):
             active_examples = self.rng.sample(all_active_examples, num_active_examples)
 
             # highlights the active tokens with <<>> markers
-            majority_examples = []
+            examples = []
             num_active_tokens = 0
             for example in active_examples:
                 text, _str_tokens = _prepare_text(
                     example, n_incorrect=0, threshold=0.3, highlighted=True
                 )
-                majority_examples.append(text)
+                examples.append(text)
                 num_active_tokens += (example.activations > 0).sum().item()
 
             avg_active_tokens_per_example = num_active_tokens // len(active_examples)
@@ -223,20 +223,18 @@ class IntruderScorer(Classifier):
 
             # select a random index to insert the intruder sentence
             intruder_index = self.rng.randint(0, num_active_examples)
-            majority_examples.insert(intruder_index, intruder_sentence)
+            examples.insert(intruder_index, intruder_sentence)
 
-            activations = [example.activations.tolist() for example in active_examples]
-            tokens = [example.str_tokens for example in active_examples]
-            activations.insert(intruder_index, intruder.activations.tolist())
-            tokens.insert(intruder_index, intruder.str_tokens)
+            example_activations = [example.activations.tolist() for example in examples]
+            example_tokens = [example.str_tokens for example in examples]
 
             batches.append(
                 IntruderSentence(
-                    examples=majority_examples,
+                    examples=examples,
                     intruder_index=intruder_index,
                     chosen_quantile=active_quantile,
-                    activations=activations,
-                    tokens=tokens,
+                    activations=example_activations,
+                    tokens=example_tokens,
                     intruder_distance=intruder.distance,
                 )
             )

--- a/delphi/scorers/classifier/intruder.py
+++ b/delphi/scorers/classifier/intruder.py
@@ -305,20 +305,11 @@ class IntruderScorer(Classifier):
         prompt = self._build_prompt(sample)
         try:
             response = await self.client.generate(prompt, **self.generation_kwargs)
+            interpretation, prediction = self._parse(response.text)
         except Exception as e:
-            logger.error(f"Error generating text: {e}")
-            response = None
-
-        if response is None:
+            logger.error(str(e))
             # default result is a error
             return IntruderResult()
-        else:
-            try:
-                interpretation, prediction = self._parse(response.text)
-            except Exception as e:
-                logger.error(f"Parsing selections failed: {e}")
-                # default result is a error
-                return IntruderResult()
 
         # check that the only prediction is the intruder
         correct = prediction == sample.intruder_index

--- a/delphi/scorers/classifier/intruder.py
+++ b/delphi/scorers/classifier/intruder.py
@@ -269,7 +269,7 @@ class IntruderScorer(Classifier):
         """
 
         examples = "\n".join(
-            f"Example {i}: {example}" for i, example in enumerate(sample.examples)
+            f"Example {i}:{example}" for i, example in enumerate(sample.examples)
         )
 
         return self.prompt(examples=examples)

--- a/delphi/scorers/classifier/intruder.py
+++ b/delphi/scorers/classifier/intruder.py
@@ -8,8 +8,7 @@ from beartype.typing import Sequence
 from delphi import logger
 
 from ...clients.client import Client
-from ...latents import (ActivatingExample, Example, LatentRecord,
-                        NonActivatingExample)
+from ...latents import ActivatingExample, Example, LatentRecord, NonActivatingExample
 from .classifier import Classifier, ScorerResult
 from .prompts.intruder_prompt import prompt as intruder_prompt
 from .sample import _prepare_text

--- a/delphi/scorers/classifier/sample.py
+++ b/delphi/scorers/classifier/sample.py
@@ -1,8 +1,6 @@
 import random
-from collections import deque
 from dataclasses import dataclass
-from itertools import groupby
-from typing import Callable, NamedTuple
+from typing import NamedTuple
 
 import torch
 
@@ -90,60 +88,48 @@ def _prepare_text(
     threshold: float,
     highlighted: bool,
 ) -> tuple[str, list[str]]:
-    assert n_incorrect >= 0, (
-        "n_incorrect must be 0 if highlighting correct example "
-        "or positive if creating false positives. "
-        f"Got {n_incorrect}"
-    )
-
     str_toks = example.str_tokens
     assert str_toks is not None, "str_toks were not set"
+    clean = "".join(str_toks)
 
     # Just return text if there's no highlighting
     if not highlighted:
-        clean = "".join(str_toks)
-
         return clean, str_toks
 
-    abs_threshold = threshold * example.max_activation
+    threshold = threshold * example.max_activation
 
     # Highlight tokens with activations above threshold
     # if correct example
     if n_incorrect == 0:
 
-        def is_above_activation_threshold(i: int) -> bool:
-            return example.activations[i] >= abs_threshold
+        def threshold_check(i):
+            return example.activations[i] >= threshold
 
-        return _highlight(str_toks, is_above_activation_threshold), str_toks
+        return _highlight(str_toks, threshold_check), str_toks
 
     # Highlight n_incorrect tokens with activations
     # below threshold if incorrect example
-    tokens_below_threshold = torch.nonzero(
-        example.activations <= abs_threshold
-    ).squeeze()
+    below_threshold = torch.nonzero(example.activations <= threshold).squeeze()
 
     # Rare case where there are no tokens below threshold
-    if tokens_below_threshold.dim() == 0:
-        logger.error(
-            f"Tried to prepare false-positive example with {n_incorrect} tokens "
-            "incorrectly highlighted, but no tokens were below activation threshold."
-        )
+    if below_threshold.dim() == 0:
+        logger.error("Failed to prepare example.")
         return DEFAULT_MESSAGE, str_toks
 
     random.seed(22)
 
-    num_tokens_to_highlight = min(n_incorrect, tokens_below_threshold.shape[0])
+    n_incorrect = min(n_incorrect, len(below_threshold))
 
     # The activating token is always ctx_len - ctx_len//4
-    # so we always highlight this one, and if num_tokens_to_highlight > 1
-    # we highlight num_tokens_to_highlight - 1 random ones
+    # so we always highlight this one, and if  n_incorrect > 1
+    # we highlight n_incorrect-1 random ones
     token_pos = len(str_toks) - len(str_toks) // 4
-    if token_pos in tokens_below_threshold:
+    if token_pos in below_threshold:
         random_indices = [token_pos]
 
-        num_remaining_tokens_to_highlight = num_tokens_to_highlight - 1
+        num_remaining_tokens_to_highlight = n_incorrect - 1
         if num_remaining_tokens_to_highlight > 0:
-            remaining_tokens_below_threshold = tokens_below_threshold.tolist()
+            remaining_tokens_below_threshold = below_threshold.tolist()
             remaining_tokens_below_threshold.remove(token_pos)
 
             random_indices.extend(
@@ -153,32 +139,31 @@ def _prepare_text(
                 )
             )
     else:
-        random_indices = random.sample(
-            tokens_below_threshold.tolist(), num_tokens_to_highlight
-        )
+        random_indices = random.sample(below_threshold.tolist(), n_incorrect)
 
     random_indices = set(random_indices)
 
-    def is_false_positive(i):
+    def check(i):
         return i in random_indices
 
-    return _highlight(str_toks, is_false_positive), str_toks
+    return _highlight(str_toks, check), str_toks
 
 
-def _highlight(tokens: list[str], check: Callable[[int], bool]) -> str:
-    result: deque[str] = deque()
+def _highlight(tokens, check):
+    result = []
 
-    tokens_grouped_by_check_fn = groupby(
-        enumerate(tokens), key=lambda item: check(item[0])
-    )
+    i = 0
+    while i < len(tokens):
+        if check(i):
+            result.append(L)
 
-    for should_highlight, token_group in tokens_grouped_by_check_fn:
-        highlighted_tokens = deque(token for _token_index, token in token_group)
+            while i < len(tokens) and check(i):
+                result.append(tokens[i])
+                i += 1
 
-        if should_highlight:
-            highlighted_tokens.appendleft(L)
-            highlighted_tokens.append(R)
-
-        result.extend(highlighted_tokens)
+            result.append(R)
+        else:
+            result.append(tokens[i])
+            i += 1
 
     return "".join(result)


### PR DESCRIPTION
in `delphi.scorers.classifier.sample._prepare_text`, i believe i've found a bug when calling it with `n_incorrect > 1`(i.e. producing a false positive sample by incorrectly highlighting more than 1 non-activating token). i've added a comment to the location of the bug with an explanation.

additionally, in `delphi.scorers.classifier.intruder.IntruderScorer._build_prompt` (the method used to format a list of intruder examples into a prompt for the scorer model), there is an inconsistency with few-shot examples that i've also highlighted in a comment

there are also a bunch of smaller stylistic/readability changes, feel free to push back on these.